### PR TITLE
UnTar: skip the '.' archive root entry

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -347,6 +347,9 @@ func UnTar(r io.Reader, dest string) ([]string, error) {
 			return nil, err
 		}
 		cleanedName := filepath.Clean(hdr.Name)
+		if cleanedName == "." {
+			continue
+		}
 		if err := ExtractFile(dest, hdr, cleanedName, tr); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When untarring an archive whose root is `.` (for example a build context tar), `UnTar` passed the `.` entry to `ExtractFile`, which resolves to the destination directory itself and reapplies the entry's mode and ownership onto it. Skipping the `.` entry leaves the destination directory untouched.
