### PR TITLE
assume root-fs always exists

### DIFF
--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -196,19 +196,15 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 	timer := timing.Start("Resolving Paths")
 
 	filesToAdd := []string{}
-	resolvedFiles, err := filesystem.ResolvePaths(changedPaths, s.ignorelist)
-	if err != nil {
-		return nil, nil, err
-	}
-	for _, path := range resolvedFiles {
-		if util.CheckIgnoreList(path) {
+	for _, path := range changedPaths {
+		if util.IsInProvidedIgnoreList(path, s.ignorelist) {
 			logrus.Debugf("Not adding %s to layer, as it's ignored", path)
 			continue
 		}
 		filesToAdd = append(filesToAdd, path)
 	}
 	// Ignore-list filtering can only reduce the file set.
-	assert.Assert("snapshot.scan.files-count", len(filesToAdd) <= len(resolvedFiles), "scanFullFilesystem: filesToAdd (%d) exceeds resolvedFiles (%d)", len(resolvedFiles), len(filesToAdd))
+	assert.Assert("snapshot.scan.files-count", len(filesToAdd) <= len(changedPaths), "scanFullFilesystem: filesToAdd (%d) exceeds changedPaths (%d)", len(changedPaths), len(filesToAdd))
 
 	logrus.Debugf("Adding to layer: %v", filesToAdd)
 	logrus.Debugf("Deleting in layer: %v", deletedPaths)

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -221,7 +221,6 @@ func TestSnapshotFSReplaceDirWithLink(t *testing.T) {
 	testDirWithoutLeadingSlash := strings.TrimLeft(testDir, "/")
 	expectedFiles := []string{
 		filepath.Join(testDirWithoutLeadingSlash, "bar"),
-		filepath.Join(testDirWithoutLeadingSlash, "foo"),
 	}
 	for _, path := range parentDirectoriesWithoutLeadingSlash(filepath.Join(testDir, "foo")) {
 		if path == config.RootDir {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

buildkit never adds `/` to the tar record, even if we change permissions etc.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
