### PR TITLE
1713: heredoc "<<EOF" syntax support for RUN statements

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_1713
+++ b/integration/dockerfiles/Dockerfile_test_issue_1713
@@ -1,0 +1,14 @@
+FROM busybox
+RUN <<EOF
+touch /tmp/bli
+touch /tmp/bla
+touch /tmp/blubb
+ls -la /tmp
+EOF
+
+RUN cat <<file1.txt > /tmp/file1.txt && cat <<file2.txt > /tmp/file2.txt
+Hello from file1
+file1.txt
+Hello from file2
+file2.txt
+RUN ls -la /tmp && cat /tmp/*.txt

--- a/integration/images.go
+++ b/integration/images.go
@@ -75,6 +75,7 @@ var envsMap = map[string][]string{
 
 var KanikoEnv = []string{
 	"FF_KANIKO_COPY_AS_ROOT=1",
+	"FF_KANIKO_HEREDOC=1",
 }
 
 // Arguments to build Dockerfiles with when building with docker


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes https://github.com/GoogleContainerTools/kaniko/issues/1713 https://github.com/GoogleContainerTools/kaniko/issues/3351

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
