### PR TITLE
969: cache mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ expect - see [Known Issues](#known-issues).
     - [Feature Flags](#feature-flags)
       - [Flag `FF_KANIKO_COPY_AS_ROOT`](#flag-ff_kaniko_copy_as_root)
       - [Flag `FF_KANIKO_SQUASH_STAGES`](#flag-ff_kaniko_squash_stages)
+      - [Flag `FF_KANIKO_IGNORE_CACHED_MANIFEST`](#flag-ff_kaniko_ignore_cached_manifest)
+      - [Flag `FF_KANIKO_RUN_MOUNT_CACHE`](#flag-ff_kaniko_run_mount_cache)
     - [Debug Image](#debug-image)
   - [Security](#security)
     - [Verifying Signed Kaniko Images](#verifying-signed-kaniko-images)
@@ -1383,6 +1385,17 @@ Warmer does not only store the image as a tarball, but also the original manifes
 This is done to speedup manifest retrieval, but has adverse effects in some scenarios, as storing the image as a tarball actively rewrites part of the image, specifically it forces the mediatype to `vnd.docker.distribution.manifest.v2+json`. This causes the stored manifest being incompatible with the stored image. With this featureflag we ignore the manifest stored in cache and instead create the manifest from the image upon load.
 Set this flag to `true` to ignore stored manifest.json in the cache directory. Defaults to `false`.
 Currently no plans to activate.
+
+#### Flag `FF_KANIKO_RUN_MOUNT_CACHE`
+
+Set this flag to `true` to implement mount caches in `RUN` statements, ie.
+```dockerfile
+RUN --mount=type=cache,target=/var/lib/apt/lists/ \
+  apt-get update \
+  && apt-get -y install cowsay
+```
+Defaults to `false`.
+Becomes default in `v1.26.0`.
 
 ### Debug Image
 

--- a/integration/dockerfiles/Dockerfile_test_issue_969
+++ b/integration/dockerfiles/Dockerfile_test_issue_969
@@ -1,0 +1,11 @@
+FROM busybox
+
+RUN --mount=type=cache,target=/tmp/bli/bla/ \
+    touch /tmp/bli/bla/blubb
+
+RUN ls -la /tmp/ \
+    && test ! -f /tmp/bli/bla/blubb
+
+RUN --mount=type=cache,target=/tmp/bli/bla \
+    ls -la /tmp/bli/bla/ \
+    && test -f /tmp/bli/bla/blubb

--- a/integration/images.go
+++ b/integration/images.go
@@ -76,6 +76,7 @@ var envsMap = map[string][]string{
 
 var KanikoEnv = []string{
 	"FF_KANIKO_COPY_AS_ROOT=1",
+	"FF_KANIKO_RUN_MOUNT_CACHE=1",
 }
 
 // Arguments to build Dockerfiles with when building with docker

--- a/pkg/commands/run_marker.go
+++ b/pkg/commands/run_marker.go
@@ -40,7 +40,7 @@ func (r *RunMarkerCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfi
 	if err != nil {
 		return err
 	}
-	if err := runCommandInExec(config, buildArgs, r.cmd); err != nil {
+	if err := runCommandWithFlags(config, buildArgs, r.cmd); err != nil {
 		return err
 	}
 	_, r.Files, err = util.GetFSInfoMap("/", prevFilesMap)

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -44,6 +44,11 @@ var BuildContextDir = fmt.Sprintf("%s/buildcontext/", KanikoDir)
 // as tarballs in case they are needed later on
 var KanikoIntermediateStagesDir = fmt.Sprintf("%s/stages/", KanikoDir)
 
+// KanikoCacheDir is where we will store cache mount directories, ie.
+// RUN --mount=type=cache,target=/var/lib/apt/lists/
+// Contents are stored as-is.
+var KanikoCacheDir = fmt.Sprintf("%s/caches/", KanikoDir)
+
 var MountInfoPath string
 
 func init() {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/googleContainerTools/kaniko/issues/969

**Description**

This PR adds a new feature-flag  `FF_KANIKO_RUN_MOUNT_CACHE`
if set to `true`, kaniko implements cache mounts as in:
```dockerfile
RUN --mount=type=cache,target=/var/lib/apt/lists/ \
  apt-get update \
  && apt-get -y install cowsay
```

This is implemented by creating a directory `/kaniko/caches/<shasum>` for each cache-dir and swapping the local directory with the contents of that cache "mount" on request.



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
