### PR TITLE
cg160: feature-flag to ignore cached manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1377,6 +1377,13 @@ Many multi-stage Dockerfiles include intermediate stages that only become releva
 Set this flag to `true` to squash stages together. Defaults to `false`.
 Becomes default in `v1.26.0`.
 
+#### Flag `FF_KANIKO_IGNORE_CACHED_MANIFEST`
+
+Warmer does not only store the image as a tarball, but also the original manifest as a separate json file.
+This is done to speedup manifest retrieval, but has adverse effects in some scenarios, as storing the image as a tarball actively rewrites part of the image, specifically it forces the mediatype to `vnd.docker.distribution.manifest.v2+json`. This causes the stored manifest being incompatible with the stored image. With this featureflag we ignore the manifest stored in cache and instead create the manifest from the image upon load.
+Set this flag to `true` to ignore stored manifest.json in the cache directory. Defaults to `false`.
+Currently no plans to activate.
+
 ### Debug Image
 
 The kaniko executor image is based on scratch and doesn't contain a shell. We

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -214,7 +214,7 @@ func (c *cachedImage) Digest() (v1.Hash, error) {
 }
 
 func (c *cachedImage) Manifest() (*v1.Manifest, error) {
-	if c.mfst == nil {
+	if config.EnvBool("FF_KANIKO_IGNORE_CACHED_MANIFEST") || c.mfst == nil {
 		return c.Image.Manifest()
 	}
 	return c.mfst, nil


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/chainguard-dev/kaniko/issues/160

**Description**

When we cache images using warmer we store them as tarball in a local directory. Unfortunately, the tarball library we're using always forcefully rewrites the image and layer format to docker v2. 

Another downside of storing the image as a tarball is that the manifest, which is a computed property of the image is lost, meaning that everytime we load the image, we have to recompute the manifest. To overcome these performance limitations we started storing the original manifest alongside the tarball in a separate `manifest.json`. Now, upon reload we can marry the image's contents from the tarball with the manifest from the external json file.

However this approach is problematic, as in certain scenarios the image's actual contents and the advertised contents in the manifest completely run apart. In our example, even though we claim an image is still in ociv1, the actual content is dockerv2.

When we add layers to the image we don't care about the advertised mediatype from the fake manifest, but look at the actual mediatype in the image. So in this case we would add dockerv2 layers. This leads to problems when we then want to push the layers to a registry as not only are the mediatypes inside the image completely mixed up, but also don't match with reality. distribution registry, which is the underlying implementation of gitlab registry for example, but also used in our integration tests here, refuses to accept these kind of messed up images.

With this featureflag we ignore the manifest stored in the cache. This can be superseded as our plan is to move to ocilayout for the cached images anyways, so there are no plans to make this feature default as is.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
