### PR TITLE
1406: don't reuse interstage dependencies

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -55,8 +55,9 @@ const emptyTarSize = 1024
 
 // for testing
 var (
-	initializeConfig = initConfig
-	getFSFromImage   = util.GetFSFromImage
+	initializeConfig             = initConfig
+	getFSFromImage               = util.GetFSFromImage
+	mkdirPermissions os.FileMode = 0644
 )
 
 type cachePusher func(*config.KanikoOptions, string, string, string) error
@@ -894,7 +895,8 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 			return nil, err
 		}
 		dstDir := filepath.Join(config.KanikoDir, strconv.Itoa(index))
-		if err := os.MkdirAll(dstDir, 0644); err != nil {
+		_ = os.RemoveAll(dstDir)
+		if err := os.Mkdir(dstDir, mkdirPermissions); err != nil {
 			return nil, errors.Wrap(err,
 				fmt.Sprintf("to create workspace for stage %s",
 					stageIdxToDigest[strconv.Itoa(index)],

--- a/pkg/executor/copy_multistage_test.go
+++ b/pkg/executor/copy_multistage_test.go
@@ -187,9 +187,11 @@ func setupMultistageTests(t *testing.T) (string, func()) {
 	//          - exec.link -> ../exec
 	//      exec
 
-	// Make directory for stage or else the executor will create with permissions 0664
+	// Overwrite permissions used to create folder for stage,
+	// otherwise executor will create it using 0664
 	// and we will run into issue https://github.com/golang/go/issues/22323
-	if err := os.MkdirAll(filepath.Join(testDir, "kaniko/0"), 0755); err != nil {
+	mkdirPermissions = 0755
+	if err := os.MkdirAll(filepath.Join(testDir, "kaniko"), 0755); err != nil {
 		t.Fatal(err)
 	}
 	workspace := filepath.Join(testDir, "workspace")


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/GoogleContainerTools/kaniko/issues/1406

**Description**

Inter-stage dependencies are stored as plain folders, not tarballs, in `/kaniko`, ie. `/kaniko/0`. When invoking kaniko multiple times in the same build context, these dependencies do persist between calls. As they are stored as plain folders with a non-unique name, the dependencies of different invocations can get merged together resulting in nonsensical build outputs. To solve this, always remove leftover dependencies before copying the folders over.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
