### PR TITLE
mz334: multistage cache lookahead

### DIFF
--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -93,6 +93,9 @@ func TestRun(t *testing.T) {
 							}
 
 							opts := config.KanikoOptions{}
+							executor.FakeCache = &executor.FakeLayerCache{
+								KeySequence: test.KeySequence,
+							}
 							exec := &cobra.Command{
 								Use: "kaniko",
 							}

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/osscontainertools/kaniko/cmd/executor/cmd"
 	testissuemz195 "github.com/osscontainertools/kaniko/golden/testdata/test_issue_mz195"
 	testissuemz333 "github.com/osscontainertools/kaniko/golden/testdata/test_issue_mz333"
+	testissuemz334 "github.com/osscontainertools/kaniko/golden/testdata/test_issue_mz334"
 	testissuemz338 "github.com/osscontainertools/kaniko/golden/testdata/test_issue_mz338"
 	testissuemz487 "github.com/osscontainertools/kaniko/golden/testdata/test_issue_mz487"
 	testunittests "github.com/osscontainertools/kaniko/golden/testdata/test_unittests"
@@ -62,6 +63,7 @@ func renderCommand(env map[string]string, args []string) string {
 var allTests = map[string][]types.GoldenTests{
 	"test_issue_mz195": {testissuemz195.Tests},
 	"test_issue_mz333": {testissuemz333.Tests},
+	"test_issue_mz334": {testissuemz334.Tests},
 	"test_issue_mz338": {testissuemz338.Tests},
 	"test_issue_mz487": {testissuemz487.Tests},
 	"test_unittests":   testunittests.Tests,

--- a/golden/testdata/test_issue_mz195/plans/fourth
+++ b/golden/testdata/test_issue_mz195/plans/fourth
@@ -1,5 +1,4 @@
 FROM debian:12.10 AS first-stage
-UNPACK debian:12.10
 SAVE STAGE /kaniko/stages/0
 CLEAN
 

--- a/golden/testdata/test_issue_mz195/plans/noise
+++ b/golden/testdata/test_issue_mz195/plans/noise
@@ -1,2 +1,1 @@
 FROM debian:12.10 AS noise
-UNPACK debian:12.10

--- a/golden/testdata/test_issue_mz195/plans/normal
+++ b/golden/testdata/test_issue_mz195/plans/normal
@@ -1,5 +1,4 @@
 FROM debian:12.10 AS first-stage
-UNPACK debian:12.10
 SAVE STAGE /kaniko/stages/0
 CLEAN
 

--- a/golden/testdata/test_issue_mz195/plans/noskip
+++ b/golden/testdata/test_issue_mz195/plans/noskip
@@ -1,10 +1,8 @@
 FROM debian:12.10 AS first-stage
-UNPACK debian:12.10
 SAVE STAGE /kaniko/stages/0
 CLEAN
 
 FROM first-stage AS second-stage
-UNPACK /kaniko/stages/0
 SAVE STAGE /kaniko/stages/1
 CLEAN
 
@@ -21,8 +19,6 @@ SAVE STAGE /kaniko/stages/3
 CLEAN
 
 FROM debian:12.10 AS noise
-UNPACK debian:12.10
 CLEAN
 
 FROM fourth-stage AS fifth-stage
-UNPACK /kaniko/stages/3

--- a/golden/testdata/test_issue_mz195/plans/nosquash
+++ b/golden/testdata/test_issue_mz195/plans/nosquash
@@ -1,10 +1,8 @@
 FROM debian:12.10 AS first-stage
-UNPACK debian:12.10
 SAVE STAGE /kaniko/stages/0
 CLEAN
 
 FROM first-stage AS second-stage
-UNPACK /kaniko/stages/0
 SAVE STAGE /kaniko/stages/1
 CLEAN
 
@@ -21,4 +19,3 @@ SAVE STAGE /kaniko/stages/3
 CLEAN
 
 FROM fourth-stage AS fifth-stage
-UNPACK /kaniko/stages/3

--- a/golden/testdata/test_issue_mz195/plans/push
+++ b/golden/testdata/test_issue_mz195/plans/push
@@ -1,5 +1,4 @@
 FROM debian:12.10 AS first-stage
-UNPACK debian:12.10
 SAVE STAGE /kaniko/stages/0
 CLEAN
 

--- a/golden/testdata/test_issue_mz334/Dockerfile
+++ b/golden/testdata/test_issue_mz334/Dockerfile
@@ -1,0 +1,6 @@
+FROM busybox AS base
+RUN touch /blubb
+
+FROM base AS final
+COPY --from=base /blubb /blubb
+RUN ls -lah /blubb

--- a/golden/testdata/test_issue_mz334/Dockerfile
+++ b/golden/testdata/test_issue_mz334/Dockerfile
@@ -1,6 +1,13 @@
-FROM busybox AS base
+FROM busybox AS first
 RUN touch /blubb
 
-FROM base AS final
-COPY --from=base /blubb /blubb
+FROM first AS second
+RUN touch /bla
+
+FROM second AS third
+RUN touch /bli
+
+FROM second AS final
+COPY --from=first /blubb /blubb
+COPY --from=third /bli /bli
 RUN ls -lah /blubb

--- a/golden/testdata/test_issue_mz334/plans/cached
+++ b/golden/testdata/test_issue_mz334/plans/cached
@@ -1,0 +1,8 @@
+FROM busybox AS final
+UNPACK busybox
+CACHE HIT: b0db5c4dc0ee6072dc9f3e18194c1cf4745367521c6a6bb4a8ebb269be5e7c82
+RUN touch /blubb
+CACHE HIT: d9bc52c744d2c8b71b7cddc067835bb19cbd1c4582ccc7c080c21cab0e738902
+COPY --from=base /blubb /blubb
+CACHE HIT: 5d60f8ab2a0f13a3b795b4129fd35f0d31312a7eead176f4786d07d08d7b1887
+RUN ls -lah /blubb

--- a/golden/testdata/test_issue_mz334/plans/cached
+++ b/golden/testdata/test_issue_mz334/plans/cached
@@ -1,4 +1,4 @@
-FROM busybox AS base
+FROM busybox AS first
 UNPACK busybox
 CACHE HIT: b0db5c4dc0ee6072dc9f3e18194c1cf4745367521c6a6bb4a8ebb269be5e7c82
 RUN touch /blubb
@@ -6,7 +6,21 @@ SAVE STAGE /kaniko/stages/0
 SAVE FILES [/blubb] /kaniko/deps/0
 CLEAN
 
-FROM base AS final
-UNPACK /kaniko/stages/0
-COPY --from=base /blubb /blubb
+FROM first AS second
+CACHE HIT: 3576b2d5bfde80d864d0b057a67fea6796fcddc8c0d29875abbce46209d5a5eb
+RUN touch /bla
+SAVE STAGE /kaniko/stages/1
+CLEAN
+
+FROM second AS third
+UNPACK /kaniko/stages/1
+CACHE HIT: 1997ccce84320d3b5363cb02a377748cc30451928a285d98fe8f80161b0b7ab1
+RUN touch /bli
+SAVE FILES [/bli] /kaniko/deps/2
+CLEAN
+
+FROM second AS final
+UNPACK /kaniko/stages/1
+COPY --from=first /blubb /blubb
+COPY --from=third /bli /bli
 RUN ls -lah /blubb

--- a/golden/testdata/test_issue_mz334/plans/cached
+++ b/golden/testdata/test_issue_mz334/plans/cached
@@ -1,8 +1,12 @@
-FROM busybox AS final
+FROM busybox AS base
 UNPACK busybox
 CACHE HIT: b0db5c4dc0ee6072dc9f3e18194c1cf4745367521c6a6bb4a8ebb269be5e7c82
 RUN touch /blubb
-CACHE HIT: d9bc52c744d2c8b71b7cddc067835bb19cbd1c4582ccc7c080c21cab0e738902
+SAVE STAGE /kaniko/stages/0
+SAVE FILES [/blubb] /kaniko/deps/0
+CLEAN
+
+FROM base AS final
+UNPACK /kaniko/stages/0
 COPY --from=base /blubb /blubb
-CACHE HIT: 5d60f8ab2a0f13a3b795b4129fd35f0d31312a7eead176f4786d07d08d7b1887
 RUN ls -lah /blubb

--- a/golden/testdata/test_issue_mz334/plans/plan
+++ b/golden/testdata/test_issue_mz334/plans/plan
@@ -1,5 +1,6 @@
 FROM busybox AS base
 UNPACK busybox
+CACHE MISS: b0db5c4dc0ee6072dc9f3e18194c1cf4745367521c6a6bb4a8ebb269be5e7c82
 RUN touch /blubb
 SAVE STAGE /kaniko/stages/0
 SAVE FILES [/blubb] /kaniko/deps/0
@@ -7,5 +8,7 @@ CLEAN
 
 FROM base AS final
 UNPACK /kaniko/stages/0
+CACHE MISS: d9bc52c744d2c8b71b7cddc067835bb19cbd1c4582ccc7c080c21cab0e738902
 COPY --from=base /blubb /blubb
+CACHE MISS: 5d60f8ab2a0f13a3b795b4129fd35f0d31312a7eead176f4786d07d08d7b1887
 RUN ls -lah /blubb

--- a/golden/testdata/test_issue_mz334/plans/plan
+++ b/golden/testdata/test_issue_mz334/plans/plan
@@ -1,0 +1,11 @@
+FROM busybox AS base
+UNPACK busybox
+RUN touch /blubb
+SAVE STAGE /kaniko/stages/0
+SAVE FILES [/blubb] /kaniko/deps/0
+CLEAN
+
+FROM base AS final
+UNPACK /kaniko/stages/0
+COPY --from=base /blubb /blubb
+RUN ls -lah /blubb

--- a/golden/testdata/test_issue_mz334/plans/plan
+++ b/golden/testdata/test_issue_mz334/plans/plan
@@ -1,4 +1,4 @@
-FROM busybox AS base
+FROM busybox AS first
 UNPACK busybox
 CACHE MISS: b0db5c4dc0ee6072dc9f3e18194c1cf4745367521c6a6bb4a8ebb269be5e7c82
 RUN touch /blubb
@@ -6,7 +6,22 @@ SAVE STAGE /kaniko/stages/0
 SAVE FILES [/blubb] /kaniko/deps/0
 CLEAN
 
-FROM base AS final
+FROM first AS second
 UNPACK /kaniko/stages/0
-COPY --from=base /blubb /blubb
+CACHE MISS: 3576b2d5bfde80d864d0b057a67fea6796fcddc8c0d29875abbce46209d5a5eb
+RUN touch /bla
+SAVE STAGE /kaniko/stages/1
+CLEAN
+
+FROM second AS third
+UNPACK /kaniko/stages/1
+CACHE MISS: 1997ccce84320d3b5363cb02a377748cc30451928a285d98fe8f80161b0b7ab1
+RUN touch /bli
+SAVE FILES [/bli] /kaniko/deps/2
+CLEAN
+
+FROM second AS final
+UNPACK /kaniko/stages/1
+COPY --from=first /blubb /blubb
+COPY --from=third /bli /bli
 RUN ls -lah /blubb

--- a/golden/testdata/test_issue_mz334/plans/plan
+++ b/golden/testdata/test_issue_mz334/plans/plan
@@ -8,7 +8,5 @@ CLEAN
 
 FROM base AS final
 UNPACK /kaniko/stages/0
-CACHE MISS: d9bc52c744d2c8b71b7cddc067835bb19cbd1c4582ccc7c080c21cab0e738902
 COPY --from=base /blubb /blubb
-CACHE MISS: 5d60f8ab2a0f13a3b795b4129fd35f0d31312a7eead176f4786d07d08d7b1887
 RUN ls -lah /blubb

--- a/golden/testdata/test_issue_mz334/test.go
+++ b/golden/testdata/test_issue_mz334/test.go
@@ -7,8 +7,18 @@ var Tests = types.GoldenTests{
 	Dockerfile: "Dockerfile",
 	Tests: []types.GoldenTest{
 		{
-			Args: []string{"--no-push"},
-			Plan: "plan",
+			Args:        []string{"--no-push", "--cache", "--cache-copy-layers"},
+			KeySequence: []string{},
+			Plan:        "plan",
+		},
+		{
+			Args: []string{"--no-push", "--cache", "--cache-copy-layers"},
+			KeySequence: []string{
+				"b0db5c4dc0ee6072dc9f3e18194c1cf4745367521c6a6bb4a8ebb269be5e7c82",
+				"d9bc52c744d2c8b71b7cddc067835bb19cbd1c4582ccc7c080c21cab0e738902",
+				"5d60f8ab2a0f13a3b795b4129fd35f0d31312a7eead176f4786d07d08d7b1887",
+			},
+			Plan: "cached",
 		},
 	},
 }

--- a/golden/testdata/test_issue_mz334/test.go
+++ b/golden/testdata/test_issue_mz334/test.go
@@ -1,0 +1,14 @@
+package testissuemz334
+
+import "github.com/osscontainertools/kaniko/golden/types"
+
+var Tests = types.GoldenTests{
+	Name:       "test_issue_mz334",
+	Dockerfile: "Dockerfile",
+	Tests: []types.GoldenTest{
+		{
+			Args: []string{"--no-push"},
+			Plan: "plan",
+		},
+	},
+}

--- a/golden/testdata/test_issue_mz334/test.go
+++ b/golden/testdata/test_issue_mz334/test.go
@@ -15,8 +15,6 @@ var Tests = types.GoldenTests{
 			Args: []string{"--no-push", "--cache", "--cache-copy-layers"},
 			KeySequence: []string{
 				"b0db5c4dc0ee6072dc9f3e18194c1cf4745367521c6a6bb4a8ebb269be5e7c82",
-				"d9bc52c744d2c8b71b7cddc067835bb19cbd1c4582ccc7c080c21cab0e738902",
-				"5d60f8ab2a0f13a3b795b4129fd35f0d31312a7eead176f4786d07d08d7b1887",
 			},
 			Plan: "cached",
 		},

--- a/golden/testdata/test_issue_mz334/test.go
+++ b/golden/testdata/test_issue_mz334/test.go
@@ -15,6 +15,8 @@ var Tests = types.GoldenTests{
 			Args: []string{"--no-push", "--cache", "--cache-copy-layers"},
 			KeySequence: []string{
 				"b0db5c4dc0ee6072dc9f3e18194c1cf4745367521c6a6bb4a8ebb269be5e7c82",
+				"3576b2d5bfde80d864d0b057a67fea6796fcddc8c0d29875abbce46209d5a5eb",
+				"1997ccce84320d3b5363cb02a377748cc30451928a285d98fe8f80161b0b7ab1",
 			},
 			Plan: "cached",
 		},

--- a/golden/types/types.go
+++ b/golden/types/types.go
@@ -17,9 +17,10 @@ limitations under the License.
 package types
 
 type GoldenTest struct {
-	Args []string
-	Env  map[string]string
-	Plan string
+	Args        []string
+	Env         map[string]string
+	KeySequence []string
+	Plan        string
 }
 
 type GoldenTests struct {

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -346,7 +346,7 @@ func MakeKanikoStages(opts *config.KanikoOptions, stages []instructions.Stage, m
 					// We squash the base stage into the current stage because,
 					// no one else depends on the base stage so it can be freely moved,
 					// the current stage might depend on other stages so it is not safe to move it.
-					kanikoStages[i] = squash(sb, s)
+					kanikoStages[i] = Squash(sb, s)
 					stagesDependencies[s.BaseImageIndex] = 0
 				}
 			}
@@ -426,7 +426,7 @@ func filterOnBuild(cmds []instructions.Command) []instructions.Command {
 	return out
 }
 
-func squash(a, b config.KanikoStage) config.KanikoStage {
+func Squash(a, b config.KanikoStage) config.KanikoStage {
 	acmds := filterOnBuild(a.Commands)
 	return config.KanikoStage{
 		Name:                   b.Name,

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -213,9 +213,7 @@ func populateCompositeKey(command commands.DockerCommand, files []string, compos
 	compositeKey.AddKey(command.String())
 
 	for _, f := range files {
-		if err := compositeKey.AddPath(f, fileContext); err != nil {
-			return compositeKey, err
-		}
+		compositeKey.AddKey(f)
 	}
 	return compositeKey, nil
 }

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -53,10 +53,11 @@ import (
 
 // for testing
 var (
-	initializeConfig             = initConfig
-	getFSFromImage               = util.GetFSFromImage
-	mkdirPermissions os.FileMode = 0755
-	pushCache                    = pushLayerToCache
+	initializeConfig                  = initConfig
+	getFSFromImage                    = util.GetFSFromImage
+	mkdirPermissions os.FileMode      = 0755
+	pushCache                         = pushLayerToCache
+	FakeCache        cache.LayerCache = nil
 )
 
 type snapShotter interface {
@@ -73,6 +74,8 @@ type stageBuilder struct {
 	baseImageDigest string
 	cmds            []commands.DockerCommand
 	args            *dockerfile.BuildArgs
+	cacheKeys       []string
+	cacheHits       []bool
 }
 
 func makeSnapshotter(opts *config.KanikoOptions) (*snapshot.Snapshotter, error) {
@@ -139,6 +142,8 @@ func newStageBuilder(sourceImage v1.Image, args *dockerfile.BuildArgs, opts *con
 		}
 		s.cmds = append(s.cmds, command)
 	}
+	s.cacheKeys = make([]string, len(s.cmds))
+	s.cacheHits = make([]bool, len(s.cmds))
 	s.args.AddMetaArgs(stage.MetaArgs)
 	return s, nil
 }
@@ -177,6 +182,9 @@ func initConfig(img partial.WithConfigFile, opts *config.KanikoOptions) (*v1.Con
 }
 
 func newLayerCache(opts *config.KanikoOptions) cache.LayerCache {
+	if opts.Dryrun && FakeCache != nil {
+		return FakeCache
+	}
 	if isOCILayout(opts.CacheRepo) {
 		return &cache.LayoutCache{
 			Opts: opts,
@@ -256,6 +264,7 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 
 		logrus.Debugf("Optimize: cache key for command %v %v", command.String(), ck)
 		finalCacheKey = ck
+		s.cacheKeys[i] = ck
 
 		if command.ShouldCacheOutput() && !stopCache {
 			img, err := layerCache.RetrieveLayer(ck)
@@ -268,6 +277,7 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 				continue
 			}
 
+			s.cacheHits[i] = true
 			if cacheCmd := command.CacheCommand(img); cacheCmd != nil {
 				logrus.Infof("Using caching version of cmd: %s", command.String())
 				s.cmds[i] = cacheCmd
@@ -725,7 +735,16 @@ func RenderStages(stages []*stageBuilder, opts *config.KanikoOptions, fileContex
 		} else {
 			printf("UNPACK %s\n", s.stage.BaseName)
 		}
-		for _, c := range s.cmds {
+		for idx, c := range s.cmds {
+			if opts.Cache {
+				if ck := s.cacheKeys[idx]; ck != "" {
+					if s.cacheHits[idx] {
+						printf("CACHE HIT: %s\n", ck)
+					} else {
+						printf("CACHE MISS: %s\n", ck)
+					}
+				}
+			}
 			printf("%s\n", c.String())
 		}
 		if s.stage.Final {
@@ -775,6 +794,8 @@ func squash(a, b *stageBuilder) *stageBuilder {
 		baseImageDigest: a.baseImageDigest,
 		cmds:            append(acmds, b.cmds...),
 		args:            a.args,
+		cacheKeys:       append(a.cacheKeys, b.cacheKeys...),
+		cacheHits:       append(a.cacheHits, b.cacheHits...),
 	}
 }
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -221,12 +221,14 @@ func populateCompositeKey(command commands.DockerCommand, files []string, compos
 	compositeKey.AddKey(command.String())
 
 	for _, f := range files {
-		compositeKey.AddKey(f)
+		if err := compositeKey.AddPath(f, fileContext); err != nil {
+			return compositeKey, err
+		}
 	}
 	return compositeKey, nil
 }
 
-func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts *config.KanikoOptions, fileContext util.FileContext, layerCache cache.LayerCache) error {
+func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts *config.KanikoOptions, fileContext util.FileContext, layerCache cache.LayerCache, hasContext bool) error {
 	if !opts.Cache {
 		return nil
 	}
@@ -247,14 +249,17 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 		}
 		files, err := command.FilesUsedFromContext(&cfg, s.args)
 		if err != nil {
-			return fmt.Errorf("failed to get files used from context: %w", err)
+			if hasContext {
+				return fmt.Errorf("failed to get files used from context: %w", err)
+			} else {
+				break
+			}
 		}
 
 		compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, cfg.Env, fileContext)
 		if err != nil {
 			return err
 		}
-
 		logrus.Debugf("Optimize: composite key for command %v %v", command.String(), compositeKey)
 		ck, err := compositeKey.Hash()
 		if err != nil {
@@ -854,14 +859,19 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		if err != nil {
 			return nil, err
 		}
+		builderStages[sb.stage.Index] = sb
+		images[sb.stage.Index] = sourceImage
+
 		cacheKey := sb.baseImageDigest
 		if sb.stage.BaseImageStoredLocally {
-			if key := baseStageToCacheKey[sb.stage.BaseImageIndex]; key != "" {
-				cacheKey = key
+			key := baseStageToCacheKey[sb.stage.BaseImageIndex]
+			if key == "" {
+				continue
 			}
+			cacheKey = key
 		}
 		compositeKey := NewCompositeCache(cacheKey)
-		err = sb.optimize(*compositeKey, sb.cf.Config, opts, fileContext, newLayerCache(opts))
+		err = sb.optimize(*compositeKey, sb.cf.Config, opts, fileContext, newLayerCache(opts), false)
 		if err != nil {
 			return nil, err
 		}
@@ -872,9 +882,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		if len(sb.cacheKeys) > 0 {
 			finalCacheKey = sb.cacheKeys[len(sb.cacheKeys)-1]
 		}
-		builderStages[sb.stage.Index] = sb
 		baseStageToCacheKey[sb.stage.Index] = finalCacheKey
-		images[sb.stage.Index] = sb.image
 	}
 
 	// We now "count" references, it is only safe to squash
@@ -1009,6 +1017,20 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 			compositeKey = NewCompositeCache(sb.baseImageDigest)
 		}
 
+		// Apply optimizations to the instructions.
+		err := sb.optimize(*compositeKey, sb.cf.Config, opts, fileContext, newLayerCache(opts), true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to optimize instructions: %w", err)
+		}
+		finalCacheKey := ""
+		if len(sb.cacheKeys) > 0 {
+			finalCacheKey = sb.cacheKeys[len(sb.cacheKeys)-1]
+		}
+		if finalCacheKey == "" {
+			logrus.Panic("Unreachable Code: finalCacheKey should exist for each stage")
+		}
+
+		args = sb.args
 		crossStageDeps := len(crossStageDependencies[sb.stage.Index]) > 0
 		err = sb.build(*compositeKey, opts, fileContext, snapshotter, crossStageDeps)
 		if err != nil {
@@ -1041,6 +1063,15 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		if err != nil {
 			return nil, err
 		}
+
+		d, err := sourceImage.Digest()
+		if err != nil {
+			return nil, err
+		}
+		logrus.Debugf("Mapping stage idx %v to digest %v", sb.stage.Index, d.String())
+
+		digestToCacheKey[d.String()] = finalCacheKey
+		logrus.Debugf("Mapping digest %v to cachekey %v", d.String(), finalCacheKey)
 
 		if sb.stage.Final {
 			sourceImage, err = mutate.CreatedAt(sourceImage, v1.Time{Time: time.Now()})

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -218,9 +218,7 @@ func populateCompositeKey(command commands.DockerCommand, files []string, compos
 	compositeKey.AddKey(command.String())
 
 	for _, f := range files {
-		if err := compositeKey.AddPath(f, fileContext); err != nil {
-			return compositeKey, err
-		}
+		compositeKey.AddKey(f)
 	}
 	return compositeKey, nil
 }
@@ -705,7 +703,7 @@ var (
 	Out io.Writer = os.Stdout
 )
 
-func RenderStages(stages []config.KanikoStage, opts *config.KanikoOptions, fileContext util.FileContext, crossStageDependencies map[int][]string) (retErr error) {
+func RenderStages(stages []*stageBuilder, opts *config.KanikoOptions, fileContext util.FileContext, crossStageDependencies map[int][]string) (retErr error) {
 	printf := func(format string, args ...interface{}) {
 		if retErr == nil {
 			_, retErr = fmt.Fprintf(Out, format, args...)
@@ -719,27 +717,23 @@ func RenderStages(stages []config.KanikoStage, opts *config.KanikoOptions, fileC
 		printf("CLEAN\n")
 	}
 	for _, s := range stages {
-		if s.Name != "" {
-			printf("FROM %s AS %s\n", s.BaseName, s.Name)
+		if s == nil {
+			continue
+		}
+		if s.stage.Name != "" {
+			printf("FROM %s AS %s\n", s.stage.BaseName, s.stage.Name)
 		} else {
-			printf("FROM %s\n", s.BaseName)
+			printf("FROM %s\n", s.stage.BaseName)
 		}
-		if s.BaseImageStoredLocally {
-			printf("UNPACK %s%d\n", config.KanikoIntermediateStagesDir, s.BaseImageIndex)
+		if s.stage.BaseImageStoredLocally {
+			printf("UNPACK %s%d\n", config.KanikoIntermediateStagesDir, s.stage.BaseImageIndex)
 		} else {
-			printf("UNPACK %s\n", s.BaseName)
+			printf("UNPACK %s\n", s.stage.BaseName)
 		}
-		for _, c := range s.Commands {
-			command, err := commands.GetCommand(c, fileContext, opts.Secrets, opts.RunV2, opts.CacheCopyLayers, opts.CacheRunLayers)
-			if err != nil {
-				return err
-			}
-			if command == nil {
-				continue
-			}
-			printf("%s\n", command)
+		for _, c := range s.cmds {
+			printf("%s\n", c.String())
 		}
-		if s.Final {
+		if s.stage.Final {
 			if !opts.NoPush {
 				printf("PUSH %v\n", opts.Destinations)
 			}
@@ -748,12 +742,12 @@ func RenderStages(stages []config.KanikoStage, opts *config.KanikoOptions, fileC
 			}
 			return retErr
 		}
-		if s.SaveStage {
-			printf("SAVE STAGE %s%d\n", config.KanikoIntermediateStagesDir, s.Index)
+		if s.stage.SaveStage {
+			printf("SAVE STAGE %s%d\n", config.KanikoIntermediateStagesDir, s.stage.Index)
 		}
-		filesToSave := crossStageDependencies[s.Index]
+		filesToSave := crossStageDependencies[s.stage.Index]
 		if len(filesToSave) > 0 {
-			printf("SAVE FILES %v %s%d\n", filesToSave, config.KanikoInterStageDepsDir, s.Index)
+			printf("SAVE FILES %v %s%d\n", filesToSave, config.KanikoInterStageDepsDir, s.stage.Index)
 		}
 		printf("CLEAN\n\n")
 		if opts.PreserveContext && !opts.PreCleanup {
@@ -762,6 +756,31 @@ func RenderStages(stages []config.KanikoStage, opts *config.KanikoOptions, fileC
 	}
 	logrus.Panic("unreachable - we should always have a final stage")
 	return retErr
+}
+
+func filterOnBuild(cmds []commands.DockerCommand) []commands.DockerCommand {
+	var out []commands.DockerCommand
+	for _, c := range cmds {
+		switch cmd := c.(type) {
+		case *commands.OnBuildCommand:
+			// Skip ONBUILD commands
+		default:
+			out = append(out, cmd)
+		}
+	}
+	return out
+}
+
+func squash(a, b *stageBuilder) *stageBuilder {
+	acmds := filterOnBuild(a.cmds)
+	return &stageBuilder{
+		stage:           dockerfile.Squash(a.stage, b.stage),
+		image:           a.image,
+		cf:              a.cf,
+		baseImageDigest: a.baseImageDigest,
+		cmds:            append(acmds, b.cmds...),
+		args:            a.args,
+	}
 }
 
 // DoBuild executes building the Dockerfile
@@ -793,19 +812,103 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	if len(kanikoStages) == 0 {
 		logrus.Panic("no stages to build")
 	}
-	if opts.Dryrun {
-		return nil, RenderStages(kanikoStages, opts, fileContext, crossStageDependencies)
-	}
-
-	// Some stages may refer to other random images, not previous stages
-	if err := fetchExtraStages(kanikoStages, opts); err != nil {
-		return nil, err
-	}
 
 	lastStage := kanikoStages[len(kanikoStages)-1]
 	var args = dockerfile.NewBuildArgs(opts.BuildArgs)
 	err = args.InitPredefinedArgs(opts.CustomPlatform, lastStage.Name)
 	if err != nil {
+		return nil, err
+	}
+
+	builderStages := make([]*stageBuilder, lastStage.Index+1)
+	baseStageToCacheKey := make([]string, lastStage.Index+1)
+	for _, stage := range kanikoStages {
+		sb, err := newStageBuilder(
+			args, opts, stage,
+			fileContext)
+		if err != nil {
+			return nil, err
+		}
+		cacheKey := sb.baseImageDigest
+		if sb.stage.BaseImageStoredLocally {
+			if key := baseStageToCacheKey[sb.stage.BaseImageIndex]; key != "" {
+				cacheKey = key
+			}
+		}
+		compositeKey := NewCompositeCache(cacheKey)
+		finalCacheKey, err := sb.optimize(*compositeKey, sb.cf.Config, opts, fileContext, newLayerCache(opts))
+		if err != nil {
+			return nil, err
+		}
+		builderStages[sb.stage.Index] = sb
+		baseStageToCacheKey[sb.stage.Index] = finalCacheKey
+	}
+
+	// We now "count" references, it is only safe to squash
+	// stages if the references are exactly 1 and there are no COPY references
+	stagesDependencies := make(map[int]int)
+	copyDependencies := make(map[int]int)
+	stagesDependencies[lastStage.Index] = 1
+
+	for i := len(builderStages) - 1; i >= 0; i-- {
+		s := builderStages[i]
+		if s == nil {
+			continue
+		}
+		if stagesDependencies[s.stage.Index] == 0 && copyDependencies[s.stage.Index] == 0 {
+			continue
+		}
+		if s.stage.BaseImageStoredLocally {
+			stagesDependencies[s.stage.BaseImageIndex]++
+		}
+		for _, c := range s.cmds {
+			switch cmd := c.(type) {
+			case *commands.CopyCommand:
+				if copyFromIndex, err := strconv.Atoi(cmd.From()); err == nil {
+					copyDependencies[copyFromIndex]++
+				}
+			}
+		}
+	}
+
+	if opts.SkipUnusedStages && config.EnvBoolDefault("FF_KANIKO_SQUASH_STAGES", true) {
+		for _, s := range builderStages {
+			if s == nil {
+				continue
+			}
+			if s.stage.BaseImageStoredLocally && stagesDependencies[s.stage.BaseImageIndex] == 1 && copyDependencies[s.stage.BaseImageIndex] == 0 {
+				sb := builderStages[s.stage.BaseImageIndex]
+				// squash stages[i] into stages[i].BaseName
+				logrus.Infof("Squashing stages: %s into %s", s.stage.Name, sb.stage.Name)
+				// We squash the base stage into the current stage because,
+				// no one else depends on the base stage so it can be freely moved,
+				// the current stage might depend on other stages so it is not safe to move it.
+				builderStages[s.stage.Index] = squash(sb, s)
+				stagesDependencies[s.stage.BaseImageIndex] = 0
+			}
+		}
+	}
+
+	if opts.SkipUnusedStages {
+		var onlyUsedStages []*stageBuilder
+		for _, s := range builderStages {
+			if s == nil {
+				continue
+			}
+			if stagesDependencies[s.stage.Index] > 0 || copyDependencies[s.stage.Index] > 0 {
+				s.stage.SaveStage = stagesDependencies[s.stage.Index] > 0
+				onlyUsedStages = append(onlyUsedStages, s)
+			}
+		}
+		builderStages = onlyUsedStages
+	}
+
+	if opts.Dryrun {
+		return nil, RenderStages(builderStages, opts, fileContext, crossStageDependencies)
+	}
+
+	// Some stages may refer to other random images, not previous stages
+	if err := fetchExtraStages(kanikoStages, opts); err != nil {
 		return nil, err
 	}
 
@@ -858,15 +961,12 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		})
 	}
 
-	for _, stage := range kanikoStages {
-		sb, err := newStageBuilder(
-			args, opts, stage,
-			fileContext)
-		if err != nil {
-			return nil, err
+	for _, sb := range builderStages {
+		if sb == nil {
+			continue
 		}
 		logrus.Infof("Building stage '%v' [idx: '%v', base-idx: '%v']",
-			stage.BaseName, stage.Index, stage.BaseImageIndex)
+			sb.stage.BaseName, sb.stage.Index, sb.stage.BaseImageIndex)
 
 		// Set the initial cache key to be the base image digest
 		var compositeKey *CompositeCache
@@ -876,20 +976,13 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 			compositeKey = NewCompositeCache(sb.baseImageDigest)
 		}
 
-		// Apply optimizations to the instructions.
-		finalCacheKey, err := sb.optimize(*compositeKey, sb.cf.Config, opts, fileContext, newLayerCache(opts))
-		if err != nil {
-			return nil, fmt.Errorf("failed to optimize instructions: %w", err)
-		}
-
-		args = sb.args
-		crossStageDeps := len(crossStageDependencies[stage.Index]) > 0
+		crossStageDeps := len(crossStageDependencies[sb.stage.Index]) > 0
 		err = sb.build(*compositeKey, opts, fileContext, snapshotter, crossStageDeps)
 		if err != nil {
 			return nil, fmt.Errorf("error building stage: %w", err)
 		}
 
-		reviewConfig(stage, &sb.cf.Config)
+		reviewConfig(sb.stage, &sb.cf.Config)
 
 		sourceImage, err := mutate.Config(sb.image, sb.cf.Config)
 		if err != nil {
@@ -916,16 +1009,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 			return nil, err
 		}
 
-		d, err := sourceImage.Digest()
-		if err != nil {
-			return nil, err
-		}
-		logrus.Debugf("Mapping stage idx %v to digest %v", sb.stage.Index, d.String())
-
-		digestToCacheKey[d.String()] = finalCacheKey
-		logrus.Debugf("Mapping digest %v to cachekey %v", d.String(), finalCacheKey)
-
-		if stage.Final {
+		if sb.stage.Final {
 			sourceImage, err = mutate.CreatedAt(sourceImage, v1.Time{Time: time.Now()})
 			if err != nil {
 				return nil, err
@@ -942,21 +1026,21 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 			timing.DefaultRun.Stop(t)
 			return sourceImage, nil
 		}
-		if stage.SaveStage {
-			if err := saveStageAsTarball(strconv.Itoa(stage.Index), sourceImage); err != nil {
+		if sb.stage.SaveStage {
+			if err := saveStageAsTarball(strconv.Itoa(sb.stage.Index), sourceImage); err != nil {
 				return nil, err
 			}
 		}
 
-		files, err := filesToSave(crossStageDependencies[stage.Index])
+		files, err := filesToSave(crossStageDependencies[sb.stage.Index])
 		if err != nil {
 			return nil, err
 		}
-		dstDir := filepath.Join(config.KanikoInterStageDepsDir, strconv.Itoa(stage.Index))
+		dstDir := filepath.Join(config.KanikoInterStageDepsDir, strconv.Itoa(sb.stage.Index))
 		_ = os.RemoveAll(dstDir)
 		if err := os.MkdirAll(dstDir, mkdirPermissions); err != nil {
 			return nil, fmt.Errorf("to create workspace for stage %d: %w",
-				stage.Index, err)
+				sb.stage.Index, err)
 		}
 		for _, p := range files {
 			logrus.Infof("Saving file %s for later use", p)
@@ -967,7 +1051,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 
 		// Delete the filesystem
 		if err := util.DeleteFilesystem(); err != nil {
-			return nil, fmt.Errorf("deleting file system after stage %d: %w", stage.Index, err)
+			return nil, fmt.Errorf("deleting file system after stage %d: %w", sb.stage.Index, err)
 		}
 		if opts.PreserveContext && !opts.PreCleanup {
 			if tarball == "" {

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -1028,10 +1028,11 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to optimize instructions: %w", err)
 		}
-		finalCacheKey := ""
-		if len(sb.cacheKeys) > 0 {
-			finalCacheKey = sb.cacheKeys[len(sb.cacheKeys)-1]
+
+		if len(sb.cacheKeys) == 0 {
+			logrus.Panic("Unreachable Code: empty stage")
 		}
+		finalCacheKey := sb.cacheKeys[len(sb.cacheKeys)-1]
 		if finalCacheKey == "" {
 			logrus.Panic("Unreachable Code: finalCacheKey should exist for each stage")
 		}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -67,8 +67,7 @@ type snapShotter interface {
 
 // stageBuilder contains all fields necessary to build one stage of a Dockerfile
 type stageBuilder struct {
-	index           int
-	final           bool
+	stage           config.KanikoStage
 	image           v1.Image
 	cf              *v1.ConfigFile
 	baseImageDigest string
@@ -128,8 +127,7 @@ func newStageBuilder(args *dockerfile.BuildArgs, opts *config.KanikoOptions, sta
 		return nil, err
 	}
 	s := &stageBuilder{
-		index:           stage.Index,
-		final:           stage.Final,
+		stage:           stage,
 		image:           sourceImage,
 		cf:              imageConfig,
 		baseImageDigest: digest.String(),
@@ -306,10 +304,10 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 	if crossStageDeps {
 		shouldUnpack = true
 	}
-	if s.final && opts.Materialize {
+	if s.stage.Final && opts.Materialize {
 		shouldUnpack = true
 	}
-	if s.index == 0 && opts.InitialFSUnpacked {
+	if s.stage.Index == 0 && opts.InitialFSUnpacked {
 		shouldUnpack = false
 	}
 
@@ -922,7 +920,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		if err != nil {
 			return nil, err
 		}
-		logrus.Debugf("Mapping stage idx %v to digest %v", sb.index, d.String())
+		logrus.Debugf("Mapping stage idx %v to digest %v", sb.stage.Index, d.String())
 
 		digestToCacheKey[d.String()] = finalCacheKey
 		logrus.Debugf("Mapping digest %v to cachekey %v", d.String(), finalCacheKey)

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -297,26 +297,28 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 	return nil
 }
 
-func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOptions, fileContext util.FileContext, snapshotter snapShotter, crossStageDeps bool) error {
-	// Unpack file system to root if we need to.
-	shouldUnpack := false
-	for _, cmd := range s.cmds {
-		if cmd.RequiresUnpackedFS() {
-			logrus.Infof("Unpacking rootfs as cmd %s requires it.", cmd.String())
-			shouldUnpack = true
-			break
-		}
+func shouldUnpackFilesystem(stage *stageBuilder, opts *config.KanikoOptions, crossStageDeps bool) bool {
+	if stage.stage.Index == 0 && opts.InitialFSUnpacked {
+		return false
 	}
 	if crossStageDeps {
-		shouldUnpack = true
+		return true
 	}
-	if s.stage.Final && opts.Materialize {
-		shouldUnpack = true
+	if stage.stage.Final && opts.Materialize {
+		return true
 	}
-	if s.stage.Index == 0 && opts.InitialFSUnpacked {
-		shouldUnpack = false
+	for _, cmd := range stage.cmds {
+		if cmd.RequiresUnpackedFS() {
+			logrus.Infof("Unpacking rootfs as cmd %s requires it.", cmd.String())
+			return true
+		}
 	}
+	return false
+}
 
+func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOptions, fileContext util.FileContext, snapshotter snapShotter, crossStageDeps bool) error {
+	// Unpack file system to root if we need to.
+	shouldUnpack := shouldUnpackFilesystem(s, opts, crossStageDeps)
 	if shouldUnpack {
 		t := timing.Start("FS Unpacking")
 
@@ -733,10 +735,14 @@ func RenderStages(stages []*stageBuilder, opts *config.KanikoOptions, fileContex
 		} else {
 			printf("FROM %s\n", s.stage.BaseName)
 		}
-		if s.stage.BaseImageStoredLocally {
-			printf("UNPACK %s%d\n", config.KanikoIntermediateStagesDir, s.stage.BaseImageIndex)
-		} else {
-			printf("UNPACK %s\n", s.stage.BaseName)
+		crossStageDeps := len(crossStageDependencies[s.stage.Index]) > 0
+		shouldUnpack := shouldUnpackFilesystem(s, opts, crossStageDeps)
+		if shouldUnpack {
+			if s.stage.BaseImageStoredLocally {
+				printf("UNPACK %s%d\n", config.KanikoIntermediateStagesDir, s.stage.BaseImageIndex)
+			} else {
+				printf("UNPACK %s\n", s.stage.BaseName)
+			}
 		}
 		for idx, c := range s.cmds {
 			if opts.Cache {

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -202,7 +202,8 @@ func Test_stageBuilder_shouldTakeSnapshot(t *testing.T) {
 				tt.fields.opts = &config.KanikoOptions{}
 			}
 			s := &stageBuilder{
-				cmds: tt.fields.cmds,
+				stage: tt.fields.stage,
+				cmds:  tt.fields.cmds,
 			}
 			isLastCommand := tt.args.index == len(s.cmds)-1
 			if got := shouldTakeSnapshot(tt.args.metadataOnly, isLastCommand, tt.fields.opts); got != tt.want {

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -596,7 +596,7 @@ func Test_stageBuilder_optimize(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cf := &v1.ConfigFile{}
-			lc := &fakeLayerCache{retrieve: tc.retrieve}
+			lc := &FakeLayerCache{retrieve: tc.retrieve}
 			sb := &stageBuilder{cf: cf, args: dockerfile.NewBuildArgs([]string{})}
 			ck := CompositeCache{}
 			file, err := os.CreateTemp("", "foo")
@@ -889,7 +889,7 @@ func Test_stageBuilder_build(t *testing.T) {
 		description        string
 		opts               *config.KanikoOptions
 		args               map[string]string
-		layerCache         *fakeLayerCache
+		layerCache         *FakeLayerCache
 		expectedCacheKeys  []string
 		pushedCacheKeys    []string
 		commands           []commands.DockerCommand
@@ -958,7 +958,7 @@ func Test_stageBuilder_build(t *testing.T) {
 				description: "fake command cache enabled and key in cache",
 				opts:        &config.KanikoOptions{Cache: true},
 				config:      &v1.ConfigFile{Config: v1.Config{WorkingDir: destDir}},
-				layerCache: &fakeLayerCache{
+				layerCache: &FakeLayerCache{
 					retrieve: true,
 				},
 				expectedCacheKeys: []string{hash},
@@ -991,7 +991,7 @@ func Test_stageBuilder_build(t *testing.T) {
 				description: "fake command cache enabled with tar compression disabled and key in cache",
 				opts:        &config.KanikoOptions{Cache: true, CompressedCaching: false},
 				config:      &v1.ConfigFile{Config: v1.Config{WorkingDir: destDir}},
-				layerCache: &fakeLayerCache{
+				layerCache: &FakeLayerCache{
 					retrieve: true,
 				},
 				expectedCacheKeys: []string{hash},
@@ -1016,7 +1016,7 @@ func Test_stageBuilder_build(t *testing.T) {
 		{
 			description: "fake command cache disabled and key in cache",
 			opts:        &config.KanikoOptions{Cache: false},
-			layerCache: &fakeLayerCache{
+			layerCache: &FakeLayerCache{
 				retrieve: true,
 			},
 		},
@@ -1070,7 +1070,7 @@ func Test_stageBuilder_build(t *testing.T) {
 						},
 					},
 				},
-				layerCache: &fakeLayerCache{
+				layerCache: &FakeLayerCache{
 					retrieve: true,
 					img: fakeImage{
 						ImageLayers: []v1.Layer{
@@ -1130,7 +1130,7 @@ COPY %s foo.txt
 				description: "copy command cache enabled and key is not in cache",
 				opts:        opts,
 				config:      &v1.ConfigFile{Config: v1.Config{WorkingDir: destDir}},
-				layerCache:  &fakeLayerCache{},
+				layerCache:  &FakeLayerCache{},
 				image: fakeImage{
 					ImageLayers: []v1.Layer{
 						fakeLayer{
@@ -1208,7 +1208,7 @@ COPY %s bar.txt
 				opts:        &config.KanikoOptions{Cache: true, CacheCopyLayers: true, CacheRunLayers: true},
 				rootDir:     dir,
 				config:      &v1.ConfigFile{Config: v1.Config{WorkingDir: destDir}},
-				layerCache: &fakeLayerCache{
+				layerCache: &FakeLayerCache{
 					keySequence: []string{hash1},
 					img:         image,
 				},
@@ -1282,7 +1282,7 @@ RUN foobar
 				opts:        &config.KanikoOptions{Cache: true, CacheRunLayers: true},
 				rootDir:     dir,
 				config:      &v1.ConfigFile{Config: v1.Config{WorkingDir: destDir}},
-				layerCache: &fakeLayerCache{
+				layerCache: &FakeLayerCache{
 					keySequence: []string{runHash},
 					img:         image,
 				},
@@ -1322,7 +1322,7 @@ RUN foobar
 				expectedCacheKeys: []string{hash},
 				commands:          []commands.DockerCommand{command},
 				// layer key needs to be read.
-				layerCache: &fakeLayerCache{
+				layerCache: &FakeLayerCache{
 					img:         &fakeImage{ImageLayers: []v1.Layer{fakeLayer{}}},
 					keySequence: []string{hash},
 				},
@@ -1358,7 +1358,7 @@ RUN foobar
 					"arg": "value",
 				},
 				// layer key that exists
-				layerCache: &fakeLayerCache{
+				layerCache: &FakeLayerCache{
 					img:         &fakeImage{ImageLayers: []v1.Layer{fakeLayer{}}},
 					keySequence: []string{hash},
 				},
@@ -1402,7 +1402,7 @@ RUN foobar
 					"arg": "anotherValue",
 				},
 				// layer for arg=value already exists
-				layerCache: &fakeLayerCache{
+				layerCache: &FakeLayerCache{
 					img:         &fakeImage{ImageLayers: []v1.Layer{fakeLayer{}}},
 					keySequence: []string{hash1},
 				},
@@ -1454,7 +1454,7 @@ RUN foobar
 			snap := &fakeSnapShotter{file: fileName}
 			lc := tc.layerCache
 			if lc == nil {
-				lc = &fakeLayerCache{}
+				lc = &FakeLayerCache{}
 			}
 			keys := []string{}
 			_image := tc.image

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -610,7 +610,7 @@ func Test_stageBuilder_optimize(t *testing.T) {
 			sb.cmds = []commands.DockerCommand{command}
 			sb.cacheKeys = make([]string, len(sb.cmds))
 			sb.cacheHits = make([]bool, len(sb.cmds))
-			err = sb.optimize(ck, cf.Config, tc.opts, util.FileContext{}, lc)
+			err = sb.optimize(ck, cf.Config, tc.opts, util.FileContext{}, lc, true)
 			if err != nil {
 				t.Errorf("Expected error to be nil but was %v", err)
 			}
@@ -1490,7 +1490,7 @@ RUN foobar
 				getFSFromImage = tc.mockGetFSFromImage
 			}
 			compositeKey := NewCompositeCache(sb.baseImageDigest)
-			err := sb.optimize(*compositeKey, sb.cf.Config, tc.opts, util.FileContext{}, lc)
+			err := sb.optimize(*compositeKey, sb.cf.Config, tc.opts, util.FileContext{}, lc, true)
 			if err != nil {
 				t.Errorf("failed to optimize instructions: %v", err)
 			}

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -608,7 +608,9 @@ func Test_stageBuilder_optimize(t *testing.T) {
 				cacheCommand: MockCachedDockerCommand{},
 			}
 			sb.cmds = []commands.DockerCommand{command}
-			_, err = sb.optimize(ck, cf.Config, tc.opts, util.FileContext{}, lc)
+			sb.cacheKeys = make([]string, len(sb.cmds))
+			sb.cacheHits = make([]bool, len(sb.cmds))
+			err = sb.optimize(ck, cf.Config, tc.opts, util.FileContext{}, lc)
 			if err != nil {
 				t.Errorf("Expected error to be nil but was %v", err)
 			}
@@ -1209,7 +1211,7 @@ COPY %s bar.txt
 				rootDir:     dir,
 				config:      &v1.ConfigFile{Config: v1.Config{WorkingDir: destDir}},
 				layerCache: &FakeLayerCache{
-					keySequence: []string{hash1},
+					KeySequence: []string{hash1},
 					img:         image,
 				},
 				image: image,
@@ -1283,7 +1285,7 @@ RUN foobar
 				rootDir:     dir,
 				config:      &v1.ConfigFile{Config: v1.Config{WorkingDir: destDir}},
 				layerCache: &FakeLayerCache{
-					keySequence: []string{runHash},
+					KeySequence: []string{runHash},
 					img:         image,
 				},
 				image:             image,
@@ -1324,7 +1326,7 @@ RUN foobar
 				// layer key needs to be read.
 				layerCache: &FakeLayerCache{
 					img:         &fakeImage{ImageLayers: []v1.Layer{fakeLayer{}}},
-					keySequence: []string{hash},
+					KeySequence: []string{hash},
 				},
 				rootDir: dir,
 			}
@@ -1360,7 +1362,7 @@ RUN foobar
 				// layer key that exists
 				layerCache: &FakeLayerCache{
 					img:         &fakeImage{ImageLayers: []v1.Layer{fakeLayer{}}},
-					keySequence: []string{hash},
+					KeySequence: []string{hash},
 				},
 				expectedCacheKeys: []string{hash},
 				commands:          []commands.DockerCommand{command},
@@ -1404,7 +1406,7 @@ RUN foobar
 				// layer for arg=value already exists
 				layerCache: &FakeLayerCache{
 					img:         &fakeImage{ImageLayers: []v1.Layer{fakeLayer{}}},
-					keySequence: []string{hash1},
+					KeySequence: []string{hash1},
 				},
 				expectedCacheKeys: []string{hash2},
 				pushedCacheKeys:   []string{hash2},
@@ -1473,6 +1475,8 @@ RUN foobar
 				return nil
 			}
 			sb.cmds = tc.commands
+			sb.cacheKeys = make([]string, len(sb.cmds))
+			sb.cacheHits = make([]bool, len(sb.cmds))
 			for key, value := range tc.args {
 				sb.args.AddArg(key, &value)
 			}
@@ -1486,7 +1490,7 @@ RUN foobar
 				getFSFromImage = tc.mockGetFSFromImage
 			}
 			compositeKey := NewCompositeCache(sb.baseImageDigest)
-			_, err := sb.optimize(*compositeKey, sb.cf.Config, tc.opts, util.FileContext{}, lc)
+			err := sb.optimize(*compositeKey, sb.cf.Config, tc.opts, util.FileContext{}, lc)
 			if err != nil {
 				t.Errorf("failed to optimize instructions: %v", err)
 			}

--- a/pkg/executor/fakes.go
+++ b/pkg/executor/fakes.go
@@ -123,18 +123,18 @@ func (m MockCachedDockerCommand) IsArgsEnvsRequiredInCache() bool {
 	return m.argToCompositeCache
 }
 
-type fakeLayerCache struct {
+type FakeLayerCache struct {
 	retrieve     bool
 	receivedKeys []string
 	img          v1.Image
-	keySequence  []string
+	KeySequence  []string
 }
 
-func (f *fakeLayerCache) RetrieveLayer(key string) (v1.Image, error) {
+func (f *FakeLayerCache) RetrieveLayer(key string) (v1.Image, error) {
 	f.receivedKeys = append(f.receivedKeys, key)
-	if len(f.keySequence) > 0 {
-		if f.keySequence[0] == key {
-			f.keySequence = f.keySequence[1:]
+	if len(f.KeySequence) > 0 {
+		if f.KeySequence[0] == key {
+			f.KeySequence = f.KeySequence[1:]
 			return f.img, nil
 		}
 		return f.img, errors.New("could not find layer")

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -102,8 +102,7 @@ func ResolveEnvAndWildcards(sd instructions.SourcesAndDest, fileContext FileCont
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to resolve sources: %w", err)
 	}
-	err = IsSrcsValid(sd, srcs, fileContext)
-	return srcs, dest, err
+	return srcs, dest, nil
 }
 
 // ContainsWildcards returns true if any entry in paths contains wildcards

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -102,7 +102,8 @@ func ResolveEnvAndWildcards(sd instructions.SourcesAndDest, fileContext FileCont
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to resolve sources: %w", err)
 	}
-	return srcs, dest, nil
+	err = IsSrcsValid(sd, srcs, fileContext)
+	return srcs, dest, err
 }
 
 // ContainsWildcards returns true if any entry in paths contains wildcards


### PR DESCRIPTION
Fixes https://github.com/osscontainertools/kaniko/issues/334

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

For single stage builds we perform a cache lookahead. This means if we have 100% cache hitrate we don't even need to download and unpack the files in order to create the image. The idea here is to take this lookahead functionality further to work across stages too.

Currently in multistage builds every stage is built (from cache), even if the dependent stages would have resolved to a 100% cache hitrate themselves. This means that even if we have 100% cache hitrate, we at least need to download and unpack all the files for all multistage ancestors. In case of long `FROM` chains this is partially mitigated by squashing the stages together, meaning that we in effect build a single stage. In case we have `COPY --from` though this is not possible, as we can't squash across forks & merges. If we opt to `--cache-copy-layers` we don't even use the files from the hereby built image at all and instead load them cache directly. This means that in that case downloading and unpacking was completely in vain and we can skip it completely as an optimization.

The difficulty here is that currently our cache-key depends on the file contents. This is the safe option. Even if an upstream image changes, or a multistage ancestor changes, as long as the file contents stay the same, we have a cache hit. The reverse is true too, we don't need to detect upstream changes, as we will notice them by the changed files. However, our lookahead needs to know this a priori, hence it only works if the files are guaranteed to be the same. This is for example the case if you reference images by their shasum. In that case it is guaranteed that the files will be the same after download. The same logic also applies if you provide a checksum to COPY/ADD, which is not yet implemented in kaniko, but would be a nice incentive to do so.

We can know a-priori whether a lookahead key will be stable and we can opt to do file hashing in case it is not. The only downside is that we would lose a cache hit if the a-priori key changed but the file-contents did not. Not yet sure whether we can remedy this case, as it basically would need to have two references to the same cache layer.





**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
