### PR TITLE
cg-326: use securejoin for path resolution in tar extraction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.12.0
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589
 	github.com/containerd/platforms v1.0.0-rc.2
+	github.com/cyphar/filepath-securejoin v0.6.0
 	github.com/docker/cli v29.3.0+incompatible
 	github.com/docker/docker-credential-helpers v0.9.5
 	github.com/ePirat/docker-credential-gitlabci v1.0.0
@@ -90,7 +91,6 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.18.2 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
-	github.com/cyphar/filepath-securejoin v0.6.0 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -313,7 +313,12 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 		return fmt.Errorf("tar entry %q is not allowed: references parent directory", hdr.Name)
 	}
 
-	path, err := securejoin.SecureJoin(dest, cleanedName)
+	// Resolve only the parent directory with SecureJoin, not the full path.
+	// Appending the basename lexically avoids following the final component
+	// when it is an existing symlink that the current tar entry intends to
+	// overwrite — resolving it would write to the symlink's target instead,
+	// creating self-referential symlink loops (e.g. dash -> dash).
+	secureDir, err := securejoin.SecureJoin(dest, filepath.Dir(cleanedName))
 	if err != nil {
 		// During layer extraction, symlink chains may be incomplete,
 		// causing ELOOP. Fall back to the lexical path — the OS will
@@ -321,8 +326,9 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 		if !errors.Is(err, syscall.ELOOP) {
 			return fmt.Errorf("resolving path for %q: %w", hdr.Name, err)
 		}
-		path = filepath.Join(dest, cleanedName)
+		secureDir = filepath.Join(dest, filepath.Dir(cleanedName))
 	}
+	path := filepath.Join(secureDir, filepath.Base(cleanedName))
 	base := filepath.Base(path)
 	dir := filepath.Dir(path)
 	mode := hdr.FileInfo().Mode()

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -32,6 +32,7 @@ import (
 	"syscall"
 	"time"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/moby/go-archive"
 	"github.com/moby/patternmatcher"
@@ -187,12 +188,22 @@ func GetFSFromLayers(root string, layers []v1.Layer, opts ...FSOpt) ([]string, e
 			}
 
 			cleanedName := filepath.Clean(hdr.Name)
+			if cleanedName == ".." || strings.HasPrefix(cleanedName, "../") {
+				return nil, fmt.Errorf("tar entry %q is not allowed: references parent directory", hdr.Name)
+			}
 			path := filepath.Join(root, cleanedName)
 			base := filepath.Base(path)
-			dir := filepath.Dir(path)
 
 			if strings.HasPrefix(base, archive.WhiteoutPrefix) {
-				logrus.Tracef("Whiting out %s", path)
+				// SecureJoin resolves symlinks and ensures the result stays
+				// within root, which is needed because this code path calls
+				// os.RemoveAll.
+				securePath, err := securejoin.SecureJoin(root, cleanedName)
+				if err != nil {
+					return nil, fmt.Errorf("resolving whiteout path for %q: %w", hdr.Name, err)
+				}
+				dir := filepath.Dir(securePath)
+				logrus.Tracef("Whiting out %s", securePath)
 
 				name := strings.TrimPrefix(base, archive.WhiteoutPrefix)
 				path := filepath.Join(dir, name)
@@ -298,7 +309,20 @@ func UnTar(r io.Reader, dest string) ([]string, error) {
 }
 
 func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader) error {
-	path := filepath.Join(dest, cleanedName)
+	if cleanedName == ".." || strings.HasPrefix(cleanedName, "../") {
+		return fmt.Errorf("tar entry %q is not allowed: references parent directory", hdr.Name)
+	}
+
+	path, err := securejoin.SecureJoin(dest, cleanedName)
+	if err != nil {
+		// During layer extraction, symlink chains may be incomplete,
+		// causing ELOOP. Fall back to the lexical path — the OS will
+		// encounter the same resolution failure if the path is used.
+		if !errors.Is(err, syscall.ELOOP) {
+			return fmt.Errorf("resolving path for %q: %w", hdr.Name, err)
+		}
+		path = filepath.Join(dest, cleanedName)
+	}
 	base := filepath.Base(path)
 	dir := filepath.Dir(path)
 	mode := hdr.FileInfo().Mode()
@@ -394,13 +418,30 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 				return fmt.Errorf("error removing %s to make way for new link: %w", hdr.Name, err)
 			}
 		}
-		link := filepath.Clean(filepath.Join(dest, hdr.Linkname))
+		cleanedLink := filepath.Clean(hdr.Linkname)
+		if cleanedLink == ".." || strings.HasPrefix(cleanedLink, "../") {
+			return fmt.Errorf("hardlink target %q is not allowed: references parent directory", hdr.Linkname)
+		}
+		link, err := securejoin.SecureJoin(dest, hdr.Linkname)
+		if err != nil {
+			return fmt.Errorf("invalid hardlink target %q: %w", hdr.Linkname, err)
+		}
 		if err := os.Link(link, path); err != nil {
 			return err
 		}
 
 	case tar.TypeSymlink:
 		logrus.Tracef("Symlink from %s to %s", hdr.Linkname, path)
+		// Resolve the symlink target relative to the entry's parent directory
+		// to get the effective path from the extraction root, then verify it
+		// stays within the destination.
+		effectivePath := filepath.Clean(filepath.Join(filepath.Dir(cleanedName), hdr.Linkname))
+		if filepath.IsAbs(hdr.Linkname) {
+			effectivePath = filepath.Clean(hdr.Linkname)
+		}
+		if effectivePath == ".." || strings.HasPrefix(effectivePath, "../") {
+			return fmt.Errorf("symlink target %q resolves outside destination", hdr.Linkname)
+		}
 		// The base directory for a symlink may not exist before it is created.
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return err

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -974,6 +974,115 @@ func TestExtractFile_PathTraversal(t *testing.T) {
 	})
 }
 
+func TestExtractFile_SymlinkOverwrite(t *testing.T) {
+	// Regression test: when a tar layer overwrites an existing symlink
+	// (e.g. usr/bin/sh -> dash), SecureJoin must not follow the existing
+	// symlink and write to the target. Otherwise dash becomes a
+	// self-referential symlink (dash -> dash) and /bin/sh is broken.
+
+	defaultTestTime, err := time.Parse(time.RFC3339, "1912-06-23T00:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("overwrite symlink in same directory", func(t *testing.T) {
+		dest := t.TempDir()
+
+		// Step 1: extract usr/bin/dash as a regular file.
+		dashHdr := fileHeader("usr/bin/dash", "dash-binary", 0o755, defaultTestTime)
+		if err := ExtractFile(dest, dashHdr, filepath.Clean(dashHdr.Name), bytes.NewReader([]byte("dash-binary"))); err != nil {
+			t.Fatal(err)
+		}
+
+		// Step 2: extract usr/bin/sh -> dash (symlink).
+		shHdr := linkHeader("usr/bin/sh", "dash")
+		if err := ExtractFile(dest, shHdr, filepath.Clean(shHdr.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatal(err)
+		}
+
+		// Step 3: overwrite usr/bin/sh -> dash again (simulates a later layer).
+		shHdr2 := linkHeader("usr/bin/sh", "dash")
+		if err := ExtractFile(dest, shHdr2, filepath.Clean(shHdr2.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify: sh must still point to dash.
+		target, err := os.Readlink(filepath.Join(dest, "usr/bin/sh"))
+		if err != nil {
+			t.Fatalf("reading symlink usr/bin/sh: %v", err)
+		}
+		if target != "dash" {
+			t.Fatalf("usr/bin/sh -> %q, want %q", target, "dash")
+		}
+
+		// Verify: dash must still be a regular file (not corrupted into a symlink).
+		fi, err := os.Lstat(filepath.Join(dest, "usr/bin/dash"))
+		if err != nil {
+			t.Fatalf("stat usr/bin/dash: %v", err)
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			loopTarget, _ := os.Readlink(filepath.Join(dest, "usr/bin/dash"))
+			t.Fatalf("usr/bin/dash is a symlink (-> %s), expected regular file", loopTarget)
+		}
+		got, err := os.ReadFile(filepath.Join(dest, "usr/bin/dash"))
+		if err != nil {
+			t.Fatalf("reading usr/bin/dash: %v", err)
+		}
+		if string(got) != "dash-binary" {
+			t.Fatalf("usr/bin/dash contents = %q, want %q", got, "dash-binary")
+		}
+	})
+
+	t.Run("overwrite symlink with directory indirection", func(t *testing.T) {
+		// Reproduces the bin/sh scenario where bin is a symlink to usr/bin.
+		dest := t.TempDir()
+
+		// Step 1: extract usr/bin/dash as a regular file.
+		dashHdr := fileHeader("usr/bin/dash", "dash-binary", 0o755, defaultTestTime)
+		if err := ExtractFile(dest, dashHdr, filepath.Clean(dashHdr.Name), bytes.NewReader([]byte("dash-binary"))); err != nil {
+			t.Fatal(err)
+		}
+
+		// Step 2: create bin -> usr/bin symlink.
+		binHdr := linkHeader("bin", "usr/bin")
+		if err := ExtractFile(dest, binHdr, filepath.Clean(binHdr.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatal(err)
+		}
+
+		// Step 3: extract bin/sh -> dash (through the bin symlink).
+		shHdr := linkHeader("bin/sh", "dash")
+		if err := ExtractFile(dest, shHdr, filepath.Clean(shHdr.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatal(err)
+		}
+
+		// Step 4: overwrite bin/sh -> dash again (simulates a later layer).
+		shHdr2 := linkHeader("bin/sh", "dash")
+		if err := ExtractFile(dest, shHdr2, filepath.Clean(shHdr2.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatal(err)
+		}
+
+		// bin/sh resolves through the bin -> usr/bin symlink, so the
+		// actual file is at usr/bin/sh. It must point to dash.
+		target, err := os.Readlink(filepath.Join(dest, "usr/bin/sh"))
+		if err != nil {
+			t.Fatalf("reading symlink usr/bin/sh: %v", err)
+		}
+		if target != "dash" {
+			t.Fatalf("usr/bin/sh -> %q, want %q", target, "dash")
+		}
+
+		// dash must still be a regular file.
+		fi, err := os.Lstat(filepath.Join(dest, "usr/bin/dash"))
+		if err != nil {
+			t.Fatalf("stat usr/bin/dash: %v", err)
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			loopTarget, _ := os.Readlink(filepath.Join(dest, "usr/bin/dash"))
+			t.Fatalf("usr/bin/dash is a symlink (-> %s), expected regular file", loopTarget)
+		}
+	})
+}
+
 func TestUnTar_PathTraversal(t *testing.T) {
 	makeTar := func(t *testing.T, hdrs ...tar.Header) *bytes.Buffer {
 		t.Helper()


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/osscontainertools/kaniko/issues/560

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
