### PR TITLE
mz364: warmer cache lock - part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1221,8 +1221,8 @@ Defaults to `false`.
 
 #### Flag `FF_KANIKO_WARMER_CACHE_LOCK`
 
-Multiple warmer processes sharing a cache volume can race on the final rename to `cacheDir/<digest>`. With [`FF_KANIKO_OCI_WARMER`](#flag-ff_kaniko_oci_warmer) the rename fails with `ENOTEMPTY` and the loser exits non-zero.
-Set this flag to `true` to serialize the recheck + rename via a per-digest `flock(2)` on `cacheDir/.warmer-locks/<digest>.lock`.
+Multiple warmer processes sharing a cache volume can race when warming the same image; with [`FF_KANIKO_OCI_WARMER`](#flag-ff_kaniko_oci_warmer) one of them may exit with an error.
+Set this flag to `true` to coordinate concurrent warmers and avoid redundant downloads. Corrupt or wrong-format cache entries are detected and replaced, making [`FF_KANIKO_OCI_WARMER`](#flag-ff_kaniko_oci_warmer) toggles transparent.
 Defaults to `false`.
 Becomes default in `v1.28.0`.
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -876,6 +876,8 @@ func TestWarmerTwice(t *testing.T) {
 
 			// Start a sleeping warmer container
 			dockerRunFlags := []string{"run", "--net=host"}
+			// mz364: run as host user so cache files can be removed
+			dockerRunFlags = append(dockerRunFlags, "-u", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()))
 			dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 			for _, envVariable := range WarmerEnv {
 				dockerRunFlags = append(dockerRunFlags, "-e", envVariable)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -865,6 +865,11 @@ func TestWarmerTwice(t *testing.T) {
 	t.Parallel()
 	// mz364: subtests share one cache volume so concurrent warmers exercise the TOCTOU race
 	tmpDir := t.TempDir()
+	// mz364: pre-place a broken tarball-format cache entry
+	brokenPath := filepath.Join(tmpDir, "sha256:6bc30d909583f38600edd6609e29eb3fb284ab8affce8d0389f332fc91c2dd91")
+	if err := os.WriteFile(brokenPath, []byte("legacy tarball"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	dockerfiles := map[string]bool{
 		"debian:trixie-slim": true,
 		"debian:12.10@sha256:264982ff4d18000fa74540837e2c43ca5137a53a83f8f62c7b3803c0f0bdcd56": true,  // image-index requires remote lookup

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -863,6 +863,8 @@ func TestWarmer(t *testing.T) {
 // Attempt to warm an image two times : first time should populate the cache, second time should find the image in the cache.
 func TestWarmerTwice(t *testing.T) {
 	t.Parallel()
+	// mz364: subtests share one cache volume so concurrent warmers exercise the TOCTOU race
+	tmpDir := t.TempDir()
 	dockerfiles := map[string]bool{
 		"debian:trixie-slim": true,
 		"debian:12.10@sha256:264982ff4d18000fa74540837e2c43ca5137a53a83f8f62c7b3803c0f0bdcd56": true,  // image-index requires remote lookup
@@ -871,11 +873,6 @@ func TestWarmerTwice(t *testing.T) {
 	for dockerfile, remoteLookup := range dockerfiles {
 		t.Run("test_warmer_twice_"+dockerfile, func(t *testing.T) {
 			t.Parallel()
-			tmpDir, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatal("failed to create tmpdir")
-			}
-			defer os.RemoveAll(tmpDir)
 
 			// Start a sleeping warmer container
 			dockerRunFlags := []string{"run", "--net=host"}

--- a/pkg/warmer/lock.go
+++ b/pkg/warmer/lock.go
@@ -31,15 +31,8 @@ const warmerLockDir = ".warmer-locks"
 
 // acquireCacheLock takes an exclusive flock on cacheDir/.warmer-locks/<key>.lock
 // and returns a release closure. It is used by warmToFile and ociWarmToFile to
-// serialize the final-rename step for the same digest across processes sharing
+// serialize the cache write for the same digest across processes sharing
 // the same cache volume.
-//
-// The lock is held only around the destination recheck and rename, not across
-// the image download itself. Concurrent warmers fetching the same image will
-// each pay the download cost; the lock simply guarantees that only one of
-// them moves the result into place. This avoids ENOTEMPTY rename failures
-// (FF_KANIKO_OCI_WARMER, which renames a directory) and silent overwrites
-// (the legacy tarball path, which renames a file).
 func acquireCacheLock(cacheDir, key string) (func(), error) {
 	lockDir := filepath.Join(cacheDir, warmerLockDir)
 	if err := os.MkdirAll(lockDir, 0o755); err != nil {

--- a/pkg/warmer/lock.go
+++ b/pkg/warmer/lock.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/osscontainertools/kaniko/pkg/util"
 	"golang.org/x/sys/unix"
 )
 
@@ -30,12 +31,18 @@ import (
 const warmerLockDir = ".warmer-locks"
 
 // acquireCacheLock takes an exclusive flock on cacheDir/.warmer-locks/<key>.lock
-// and returns a release closure. It is used by warmToFile and ociWarmToFile to
+// and returns a cacheLock. It is used by warmToFile and ociWarmToFile to
 // serialize the cache write for the same digest across processes sharing
 // the same cache volume.
-func acquireCacheLock(cacheDir, key string) (func(), error) {
+type cacheLock struct {
+	f        *os.File
+	released bool
+}
+
+func acquireCacheLock(cacheDir, key string) (*cacheLock, error) {
 	lockDir := filepath.Join(cacheDir, warmerLockDir)
-	if err := os.MkdirAll(lockDir, 0o755); err != nil {
+	err := os.MkdirAll(lockDir, 0o755)
+	if err != nil {
 		return nil, fmt.Errorf("creating warmer lock dir %s: %w", lockDir, err)
 	}
 
@@ -45,21 +52,20 @@ func acquireCacheLock(cacheDir, key string) (func(), error) {
 		return nil, fmt.Errorf("opening warmer lock %s: %w", lockPath, err)
 	}
 
-	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
+	err = unix.Flock(int(f.Fd()), unix.LOCK_EX)
+	if err != nil {
 		f.Close()
 		return nil, fmt.Errorf("acquiring exclusive lock on %s: %w", lockPath, err)
 	}
 
-	released := false
-	return func() {
-		if released {
-			return
-		}
-		released = true
-		// Best effort: log nothing here, callers don't have a logger handle
-		// and a failure to unlock is not something they can act on. Closing
-		// the fd will release the flock regardless via kernel cleanup.
-		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
-		_ = f.Close()
-	}, nil
+	return &cacheLock{f: f}, nil
+}
+
+// Release unlocks the flock and closes the underlying fd. It must be called
+// exactly once per successful acquireCacheLock.
+func (l *cacheLock) Release() {
+	util.Assert("warmer.cache-lock.single-release", !l.released, "Release() must not be called twice")
+	l.released = true
+	_ = unix.Flock(int(l.f.Fd()), unix.LOCK_UN)
+	_ = l.f.Close()
 }

--- a/pkg/warmer/lock_test.go
+++ b/pkg/warmer/lock_test.go
@@ -33,11 +33,11 @@ import (
 func TestAcquireCacheLock_CreatesLockDir(t *testing.T) {
 	cacheDir := t.TempDir()
 
-	release, err := acquireCacheLock(cacheDir, "sha256:abcd")
+	lock, err := acquireCacheLock(cacheDir, "sha256:abcd")
 	if err != nil {
 		t.Fatalf("acquireCacheLock returned error: %v", err)
 	}
-	defer release()
+	defer lock.Release()
 
 	lockDir := filepath.Join(cacheDir, warmerLockDir)
 	info, err := os.Stat(lockDir)
@@ -69,12 +69,12 @@ func TestAcquireCacheLock_MutualExclusionSameKey(t *testing.T) {
 	for range n {
 		go func() {
 			defer wg.Done()
-			release, err := acquireCacheLock(cacheDir, key)
+			lock, err := acquireCacheLock(cacheDir, key)
 			if err != nil {
 				t.Errorf("acquireCacheLock returned error: %v", err)
 				return
 			}
-			defer release()
+			defer lock.Release()
 
 			cur := atomic.AddInt32(&inCritical, 1)
 			for {
@@ -99,20 +99,20 @@ func TestAcquireCacheLock_MutualExclusionSameKey(t *testing.T) {
 func TestAcquireCacheLock_DifferentKeysDoNotBlock(t *testing.T) {
 	cacheDir := t.TempDir()
 
-	releaseA, err := acquireCacheLock(cacheDir, "sha256:aaa")
+	lockA, err := acquireCacheLock(cacheDir, "sha256:aaa")
 	if err != nil {
 		t.Fatalf("first acquire failed: %v", err)
 	}
-	defer releaseA()
+	defer lockA.Release()
 
 	// Acquiring a different key from the same process must succeed without
 	// blocking. We use a tight timeout via a goroutine to avoid hanging the
 	// test if the assumption breaks.
 	done := make(chan error, 1)
 	go func() {
-		release, err := acquireCacheLock(cacheDir, "sha256:bbb")
+		lock, err := acquireCacheLock(cacheDir, "sha256:bbb")
 		if err == nil {
-			release()
+			lock.Release()
 		}
 		done <- err
 	}()
@@ -127,13 +127,19 @@ func TestAcquireCacheLock_DifferentKeysDoNotBlock(t *testing.T) {
 	}
 }
 
-func TestAcquireCacheLock_ReleaseIsIdempotent(t *testing.T) {
+func TestAcquireCacheLock_DoubleReleasePanics(t *testing.T) {
 	cacheDir := t.TempDir()
 
-	release, err := acquireCacheLock(cacheDir, "sha256:once")
+	lock, err := acquireCacheLock(cacheDir, "sha256:once")
 	if err != nil {
 		t.Fatalf("acquireCacheLock returned error: %v", err)
 	}
-	release()
-	release() // must not panic, must not error
+	lock.Release()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic on double release, got nil")
+		}
+	}()
+	lock.Release()
 }

--- a/pkg/warmer/warm.go
+++ b/pkg/warmer/warm.go
@@ -122,11 +122,11 @@ func warmToFile(cacheDir, img string, opts *config.WarmerOptions) error {
 	finalMfstPath := finalCachePath + ".json"
 
 	if config.EnvBool("FF_KANIKO_WARMER_CACHE_LOCK") {
-		release, err := acquireCacheLock(cacheDir, digest.String())
+		lock, err := acquireCacheLock(cacheDir, digest.String())
 		if err != nil {
 			return fmt.Errorf("failed to acquire cache lock: %w", err)
 		}
-		defer release()
+		defer lock.Release()
 
 		_, lookupErr := cw.Local(&opts.CacheOptions, digest.String())
 		if lookupErr == nil || cache.IsExpired(lookupErr) {
@@ -183,11 +183,11 @@ func ociWarmToFile(cacheDir, img string, opts *config.WarmerOptions) error {
 	finalCachePath := path.Join(cacheDir, digest.String())
 
 	if config.EnvBool("FF_KANIKO_WARMER_CACHE_LOCK") {
-		release, err := acquireCacheLock(cacheDir, digest.String())
+		lock, err := acquireCacheLock(cacheDir, digest.String())
 		if err != nil {
 			return fmt.Errorf("failed to acquire cache lock: %w", err)
 		}
-		defer release()
+		defer lock.Release()
 
 		_, lookupErr := cw.Local(&opts.CacheOptions, digest.String())
 		if lookupErr == nil || cache.IsExpired(lookupErr) {

--- a/pkg/warmer/warm.go
+++ b/pkg/warmer/warm.go
@@ -108,7 +108,7 @@ func warmToFile(cacheDir, img string, opts *config.WarmerOptions) error {
 		ManifestWriter: mtfsFile,
 	}
 
-	digest, err := cw.Warm(img, opts)
+	cacheRef, image, digest, err := cw.Resolve(img, opts)
 	if err != nil {
 		if cache.IsAlreadyCached(err) {
 			logrus.Infof("Image already in cache: %v", img)
@@ -122,24 +122,21 @@ func warmToFile(cacheDir, img string, opts *config.WarmerOptions) error {
 	finalMfstPath := finalCachePath + ".json"
 
 	if config.EnvBool("FF_KANIKO_WARMER_CACHE_LOCK") {
-		// Serialize the recheck+rename against other warmer processes sharing
-		// this cache volume. Holding the lock only around this step (not across
-		// the download above) keeps concurrent warmers for the same image from
-		// trampling each other's renames while still letting them run in
-		// parallel against the network.
 		release, err := acquireCacheLock(cacheDir, digest.String())
 		if err != nil {
 			return fmt.Errorf("failed to acquire cache lock: %w", err)
 		}
 		defer release()
 
-		// Another warmer may have finished while we were downloading or waiting
-		// on the lock. If so, drop our copy rather than overwrite theirs — the
-		// content is by-digest immutable, so either tarball is equivalent.
 		if _, statErr := os.Stat(finalCachePath); statErr == nil {
-			logrus.Infof("Image %v became available in cache while warming; keeping existing copy", img)
+			logrus.Infof("Image %v became available in cache while waiting for lock; keeping existing copy", img)
 			return nil
 		}
+	}
+
+	if err := cw.Write(cacheRef, image); err != nil {
+		logrus.Warnf("Error while trying to warm image: %v %v", img, err)
+		return err
 	}
 
 	err = os.Rename(f.Name(), finalCachePath)
@@ -170,7 +167,7 @@ func ociWarmToFile(cacheDir, img string, opts *config.WarmerOptions) error {
 		TmpDir: tmp,
 	}
 
-	digest, err := cw.Warm(img, opts)
+	cacheRef, image, digest, err := cw.Resolve(img, opts)
 	if err != nil {
 		if cache.IsAlreadyCached(err) {
 			logrus.Infof("Image already in cache: %v", img)
@@ -183,11 +180,6 @@ func ociWarmToFile(cacheDir, img string, opts *config.WarmerOptions) error {
 	finalCachePath := path.Join(cacheDir, digest.String())
 
 	if config.EnvBool("FF_KANIKO_WARMER_CACHE_LOCK") {
-		// Serialize the recheck+rename against other warmer processes sharing
-		// this cache volume. Unlike the tarball path (which silently overwrote),
-		// os.Rename of a directory onto a non-empty destination fails with
-		// ENOTEMPTY on Linux, so unsynchronized concurrent warms here are an
-		// outright error, not just wasted work.
 		release, err := acquireCacheLock(cacheDir, digest.String())
 		if err != nil {
 			return fmt.Errorf("failed to acquire cache lock: %w", err)
@@ -195,9 +187,14 @@ func ociWarmToFile(cacheDir, img string, opts *config.WarmerOptions) error {
 		defer release()
 
 		if _, statErr := os.Stat(finalCachePath); statErr == nil {
-			logrus.Infof("Image %v became available in cache while warming; keeping existing copy", img)
+			logrus.Infof("Image %v became available in cache while waiting for lock; keeping existing copy", img)
 			return nil
 		}
+	}
+
+	if err := cw.Write(cacheRef, image); err != nil {
+		logrus.Warnf("Error while trying to warm image: %v %v", img, err)
+		return err
 	}
 
 	err = os.Rename(tmp, finalCachePath)
@@ -230,9 +227,19 @@ type Warmer struct {
 // Warm retrieves a Docker image and populates the supplied buffer with the image content and manifest
 // or returns an AlreadyCachedErr if the image is present in the cache.
 func (w *Warmer) Warm(image string, opts *config.WarmerOptions) (v1.Hash, error) {
+	cacheRef, img, digest, err := w.Resolve(image, opts)
+	if err != nil {
+		return v1.Hash{}, err
+	}
+	return digest, w.Write(cacheRef, img)
+}
+
+// Resolve fetches the image manifest and resolves its digest, short-circuiting
+// with AlreadyCachedErr if the local cache already holds it.
+func (w *Warmer) Resolve(image string, opts *config.WarmerOptions) (name.Reference, v1.Image, v1.Hash, error) {
 	cacheRef, err := name.ParseReference(image, name.WeakValidation)
 	if err != nil {
-		return v1.Hash{}, fmt.Errorf("failed to verify image name: %s: %w", image, err)
+		return nil, nil, v1.Hash{}, fmt.Errorf("failed to verify image name: %s: %w", image, err)
 	}
 
 	// mz320: If we have a digest reference, we can try a cache lookup directly.
@@ -243,7 +250,7 @@ func (w *Warmer) Warm(image string, opts *config.WarmerOptions) (v1.Hash, error)
 			cacheKey := d.DigestStr()
 			_, err := w.Local(&opts.CacheOptions, cacheKey)
 			if err == nil || cache.IsExpired(err) {
-				return v1.Hash{}, cache.AlreadyCachedErr{}
+				return nil, nil, v1.Hash{}, cache.AlreadyCachedErr{}
 			} else {
 				// mz320: But in case it is a cache miss, not all hope is lost.
 				// It could have also been the digest for an image-index.
@@ -258,12 +265,12 @@ func (w *Warmer) Warm(image string, opts *config.WarmerOptions) (v1.Hash, error)
 
 	img, err := w.Remote(image, opts.RegistryOptions, opts.CustomPlatform)
 	if err != nil || img == nil {
-		return v1.Hash{}, fmt.Errorf("failed to retrieve image: %s: %w", image, err)
+		return nil, nil, v1.Hash{}, fmt.Errorf("failed to retrieve image: %s: %w", image, err)
 	}
 
 	digest, err := img.Digest()
 	if err != nil {
-		return v1.Hash{}, fmt.Errorf("failed to retrieve digest: %s: %w", image, err)
+		return nil, nil, v1.Hash{}, fmt.Errorf("failed to retrieve digest: %s: %w", image, err)
 	}
 
 	if !opts.Force {
@@ -278,25 +285,30 @@ func (w *Warmer) Warm(image string, opts *config.WarmerOptions) (v1.Hash, error)
 			_, err = w.Local(&opts.CacheOptions, cacheKey)
 		}
 		if err == nil || cache.IsExpired(err) {
-			return v1.Hash{}, cache.AlreadyCachedErr{}
+			return nil, nil, v1.Hash{}, cache.AlreadyCachedErr{}
 		}
 	}
 
-	err = tarball.Write(cacheRef, img, w.TarWriter)
-	if err != nil {
-		return v1.Hash{}, fmt.Errorf("failed to write %s to tar buffer: %w", image, err)
+	return cacheRef, img, digest, nil
+}
+
+// Write streams the image as a Docker tarball to TarWriter and its raw
+// manifest to ManifestWriter.
+func (w *Warmer) Write(cacheRef name.Reference, img v1.Image) error {
+	if err := tarball.Write(cacheRef, img, w.TarWriter); err != nil {
+		return fmt.Errorf("failed to write %s to tar buffer: %w", cacheRef.String(), err)
 	}
 
 	mfst, err := img.RawManifest()
 	if err != nil {
-		return v1.Hash{}, fmt.Errorf("failed to retrieve manifest for %s: %w", image, err)
+		return fmt.Errorf("failed to retrieve manifest for %s: %w", cacheRef.String(), err)
 	}
 
 	if _, err := w.ManifestWriter.Write(mfst); err != nil {
-		return v1.Hash{}, fmt.Errorf("failed to save manifest to buffer for %s: %w", image, err)
+		return fmt.Errorf("failed to save manifest to buffer for %s: %w", cacheRef.String(), err)
 	}
 
-	return digest, nil
+	return nil
 }
 
 type OciWarmer struct {
@@ -308,9 +320,19 @@ type OciWarmer struct {
 // Warm retrieves a Docker image and populates the supplied buffer with the image content and manifest
 // or returns an AlreadyCachedErr if the image is present in the cache.
 func (w *OciWarmer) Warm(image string, opts *config.WarmerOptions) (v1.Hash, error) {
+	cacheRef, img, digest, err := w.Resolve(image, opts)
+	if err != nil {
+		return v1.Hash{}, err
+	}
+	return digest, w.Write(cacheRef, img)
+}
+
+// Resolve fetches the image manifest and resolves its digest, short-circuiting
+// with AlreadyCachedErr if the local cache already holds it.
+func (w *OciWarmer) Resolve(image string, opts *config.WarmerOptions) (name.Reference, v1.Image, v1.Hash, error) {
 	cacheRef, err := name.ParseReference(image, name.WeakValidation)
 	if err != nil {
-		return v1.Hash{}, fmt.Errorf("failed to verify image name: %s: %w", image, err)
+		return nil, nil, v1.Hash{}, fmt.Errorf("failed to verify image name: %s: %w", image, err)
 	}
 
 	// mz320: If we have a digest reference, we can try a cache lookup directly.
@@ -321,7 +343,7 @@ func (w *OciWarmer) Warm(image string, opts *config.WarmerOptions) (v1.Hash, err
 			cacheKey := d.DigestStr()
 			_, err := w.Local(&opts.CacheOptions, cacheKey)
 			if err == nil || cache.IsExpired(err) {
-				return v1.Hash{}, cache.AlreadyCachedErr{}
+				return nil, nil, v1.Hash{}, cache.AlreadyCachedErr{}
 			} else {
 				// mz320: But in case it is a cache miss, not all hope is lost.
 				// It could have also been the digest for an image-index.
@@ -336,12 +358,12 @@ func (w *OciWarmer) Warm(image string, opts *config.WarmerOptions) (v1.Hash, err
 
 	img, err := w.Remote(image, opts.RegistryOptions, opts.CustomPlatform)
 	if err != nil || img == nil {
-		return v1.Hash{}, fmt.Errorf("failed to retrieve image: %s: %w", image, err)
+		return nil, nil, v1.Hash{}, fmt.Errorf("failed to retrieve image: %s: %w", image, err)
 	}
 
 	digest, err := img.Digest()
 	if err != nil {
-		return v1.Hash{}, fmt.Errorf("failed to retrieve digest: %s: %w", image, err)
+		return nil, nil, v1.Hash{}, fmt.Errorf("failed to retrieve digest: %s: %w", image, err)
 	}
 
 	if !opts.Force {
@@ -356,23 +378,28 @@ func (w *OciWarmer) Warm(image string, opts *config.WarmerOptions) (v1.Hash, err
 			_, err = w.Local(&opts.CacheOptions, cacheKey)
 		}
 		if err == nil || cache.IsExpired(err) {
-			return v1.Hash{}, cache.AlreadyCachedErr{}
+			return nil, nil, v1.Hash{}, cache.AlreadyCachedErr{}
 		}
 	}
 
+	return cacheRef, img, digest, nil
+}
+
+// Write materializes the image as an ocilayout under TmpDir.
+func (w *OciWarmer) Write(cacheRef name.Reference, img v1.Image) error {
 	p, err := layout.Write(w.TmpDir, empty.Index)
 	if err != nil {
-		return v1.Hash{}, fmt.Errorf("failed to create ocilayout for: %s: %w", image, err)
+		return fmt.Errorf("failed to create ocilayout for: %s: %w", cacheRef.String(), err)
 	}
 
 	err = p.AppendImage(img, layout.WithAnnotations(map[string]string{
 		"org.opencontainers.image.ref.name": cacheRef.Name(),
 	}))
 	if err != nil {
-		return v1.Hash{}, fmt.Errorf("failed to append image %s to ocilayout: %w", image, err)
+		return fmt.Errorf("failed to append image %s to ocilayout: %w", cacheRef.String(), err)
 	}
 
-	return digest, nil
+	return nil
 }
 
 func ParseDockerfile(opts *config.WarmerOptions) ([]string, error) {

--- a/pkg/warmer/warm.go
+++ b/pkg/warmer/warm.go
@@ -128,10 +128,13 @@ func warmToFile(cacheDir, img string, opts *config.WarmerOptions) error {
 		}
 		defer release()
 
-		if _, statErr := os.Stat(finalCachePath); statErr == nil {
+		_, lookupErr := cw.Local(&opts.CacheOptions, digest.String())
+		if lookupErr == nil || cache.IsExpired(lookupErr) {
 			logrus.Infof("Image %v became available in cache while waiting for lock; keeping existing copy", img)
 			return nil
 		}
+		_ = os.RemoveAll(finalCachePath)
+		_ = os.Remove(finalMfstPath)
 	}
 
 	if err := cw.Write(cacheRef, image); err != nil {
@@ -186,10 +189,15 @@ func ociWarmToFile(cacheDir, img string, opts *config.WarmerOptions) error {
 		}
 		defer release()
 
-		if _, statErr := os.Stat(finalCachePath); statErr == nil {
+		_, lookupErr := cw.Local(&opts.CacheOptions, digest.String())
+		if lookupErr == nil || cache.IsExpired(lookupErr) {
 			logrus.Infof("Image %v became available in cache while waiting for lock; keeping existing copy", img)
 			return nil
 		}
+		_ = os.RemoveAll(finalCachePath)
+		// mz364: finalCachePath+".json" is the legacy tarball manifest sidecar.
+		// Drop this once the tarball cache format is removed (FF_KANIKO_OCI_WARMER deprecated)
+		_ = os.Remove(finalCachePath + ".json")
 	}
 
 	if err := cw.Write(cacheRef, image); err != nil {


### PR DESCRIPTION
## Summary

Follow-up to #705. Builds on @iahsanGill's per-digest `flock` primitive and extends it as follows:

| Change | What | Why |
|---|---|---|
| **Lock scope** | Splits `Warmer.Warm` / `OciWarmer.Warm` into `Resolve` + `Write`. The FF-gated lock wraps the cache re-check, the heavy tarball/layout write, **and** the rename. The thin `Warm` wrapper preserves the existing API. | Bandwidth + disk dedup: only one warmer per digest actually fetches; concurrent racers skip on the post-lock cache hit instead of all downloading in parallel. |
| **Self-healing** | Re-check under the lock uses `cw.Local()` (canonical cache check) instead of `os.Stat`. On parse error or wrong-format state, the warmer wipes the broken entry (`os.RemoveAll` + sidecar removal) before writing fresh content. | Restores pre-#705 auto-heal of broken cache entries; extends to OCI mode (where rename couldn't have healed); enables transparent tarball ↔ ocilayout migration on first warm after toggling `FF_KANIKO_OCI_WARMER`. |
| **Integration coverage** | Reverts #307's per-subtest `tmpDir` workaround in `TestWarmerTwice` (commit 9f4021ae) so subtests share one cache volume; pre-places a tarball-format broken entry; runs the warmer container as the host user so `t.TempDir` cleanup works. | Exercises both the concurrent-write race and the heal path end-to-end. |
| **`cacheLock` struct API** | `acquireCacheLock` returns `*cacheLock` with a `Release()` method instead of a closure. Asserts (via `util.Assert`) on double-release. | More conventional Go for lock-style resources; better introspection and type safety. |

Without the self-healing change, the FF-gated path would *regress* against pre-#705 `main`:

| State | Broken tarball entry | Broken OCI entry |
|---|---|---|
| Pre-#705 `main` | healed (`os.Rename` silently overwrites) | not healed (ENOTEMPTY surfaced to user) |
| #705 alone (current `main`) | **not healed** — `os.Stat` recheck treats existing file as cache hit | not healed |
| This PR | healed (`cw.Local()` detects broken → `RemoveAll` + write) | healed (same path) |

## Test plan

- [ ] `go test -race ./pkg/warmer/...` passes
- [ ] `LOCAL=1 ./scripts/integration-test.sh -run TestWarmerTwice` passes with `FF_KANIKO_WARMER_CACHE_LOCK=1` (already on in `WarmerEnv`)
- [ ] Without this PR (on `559f6a0c5`), `TestWarmerTwice` fails: subtests 2 and 3 share a resolved digest and the pre-placed broken entry isn't healed
