### PR TITLE
gate inter-stage context restore behind FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,11 @@ expect - see [Known Issues](#known-issues).
       - [Flag `FF_KANIKO_CACHE_LOOKAHEAD`](#flag-ff_kaniko_cache_lookahead)
       - [Flag `FF_KANIKO_CACHE_PROBE_AFTER_MISS`](#flag-ff_kaniko_cache_probe_after_miss)
       - [Flag `FF_KANIKO_WARMER_CACHE_LOCK`](#flag-ff_kaniko_warmer_cache_lock)
+<<<<<<< HEAD
       - [Flag `FF_KANIKO_PRESERVE_MOUNTED_PATHS`](#flag-ff_kaniko_preserve_mounted_paths)
+=======
+      - [Flag `FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE`](#flag-ff_kaniko_deprecate_inter_stage_restore)
+>>>>>>> f46373069 (gate inter-stage context restore behind FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE)
     - [Debug Image](#debug-image)
   - [Security](#security)
     - [Verifying Signed Kaniko Images](#verifying-signed-kaniko-images)
@@ -1231,6 +1235,12 @@ Becomes default in `v1.28.0`.
 
 When a container runtime bind-mounts files read-only into the build container — as the NVIDIA GPU operator does with driver artifacts (`nvidia-smi`, `libnvidia*`, firmware blobs) on GPU nodes — and a base image layer ships a directory along that mount path as a symlink, kaniko `os.RemoveAll`s the directory while unpacking to make way for the symlink. The recursive remove hits the read-only bind mount and the build fails with `unlinkat ...: device or resource busy`.
 Set this flag to `true` to skip removing a directory that contains a mounted (ignored) path: its other contents are still cleared, but the mount is preserved and the conflicting layer entry is left in place, matching how `DeleteFilesystem` already treats mounts. Defaults to `false`.
+Becomes default in `v1.28.0`.
+
+#### Flag `FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE`
+
+Deprecates the inter-stage restore performed by [`--preserve-context`](#flag---preserve-context) when used without [`--pre-cleanup`](#flag---pre-cleanup). Set to `1` to fully disable the restore between stages. The original motivation, smuggling secrets across stages, is now served by `RUN --mount=type=secret`.
+Defaults to `false`.
 Becomes default in `v1.28.0`.
 
 ### Assertion Overrides

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -397,6 +397,12 @@ func checkNoDeprecatedFlags() {
 	if opts.SkipUnusedStagesDeprecated {
 		logrus.Warn("Flag --skip-unused-stages is deprecated. This is the new default behaviour. If you want to build multiple independent stages pass them as --target instead")
 	}
+
+	if !config.EnvBool("FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE") {
+		if opts.PreserveContext && !opts.PreCleanup {
+			logrus.Warn("--preserve-context without --pre-cleanup restores the original context between stages; this is deprecated and will be removed. Use --mount=type=secret for secrets. Set FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE=1 to opt into the new behaviour now.")
+		}
+	}
 }
 
 // cacheFlagsValid makes sure the flags passed in related to caching are valid

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -21,6 +21,9 @@ The graduation lifecycle of a feature flag is:
 
 This means a new behavior is opt-in for at least two weeks and up to three months, then opt-out for a further three months before the flag disappears entirely. Users have between three and six months to react to any change. We expect most users to upgrade roughly once per quarter rather than every two weeks, so in practice the full window is available to them.
 
+- `FF_KANIKO_*` gates a new feature, `true` enables it.
+- `FF_KANIKO_DEPRECATE_*` gates the removal of existing behavior, `true` removes it.
+
 ## Do I need a feature flag?
 
 The goal of a feature flag is to let users upgrade kaniko safely without surprises. Any change that could affect whether a build succeeds, what image it produces, or how long it takes should be gated behind a flag, even if the change is correct, even if it is a performance improvement, and even if the previous behavior was technically wrong. Some users will have built workflows around the old behavior and need time to migrate. Others will be running kaniko in environments where a new code path fails in ways the old one did not. A feature flag gives them the escape hatch.

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -912,8 +912,10 @@ func RenderStages(stages []config.KanikoStage, opts *config.KanikoOptions, fileC
 			printf("SAVE FILES %v %s%d\n", filesToSave, config.KanikoInterStageDepsDir, s.Index)
 		}
 		printf("CLEAN\n\n")
-		if opts.PreserveContext && !opts.PreCleanup {
-			printf("RESTORE CONTEXT\n\n")
+		if !config.EnvBool("FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE") {
+			if opts.PreserveContext && !opts.PreCleanup {
+				printf("RESTORE CONTEXT\n\n")
+			}
 		}
 	}
 	util.Unreachable("we should always have a final stage")
@@ -1196,15 +1198,17 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		if err := util.DeleteFilesystem(); err != nil {
 			return nil, fmt.Errorf("deleting file system after stage %d: %w", stage.Index, err)
 		}
-		if opts.PreserveContext && !opts.PreCleanup {
-			if tarball == "" {
-				return nil, errors.New("context snapshot is missing")
+		if !config.EnvBool("FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE") {
+			if opts.PreserveContext && !opts.PreCleanup {
+				if tarball == "" {
+					return nil, errors.New("context snapshot is missing")
+				}
+				_, err := util.UnpackLocalTarArchive(tarball, config.RootDir)
+				if err != nil {
+					return nil, fmt.Errorf("failed to unpack context snapshot: %w", err)
+				}
+				logrus.Info("Context restored")
 			}
-			_, err := util.UnpackLocalTarArchive(tarball, config.RootDir)
-			if err != nil {
-				return nil, fmt.Errorf("failed to unpack context snapshot: %w", err)
-			}
-			logrus.Info("Context restored")
 		}
 	}
 


### PR DESCRIPTION
The inter-stage filesystem restore performed by `--preserve-context` (without `--pre-cleanup`) was introduced to smuggle secrets across multi-stage builds. That use case is now served properly by `RUN --mount=type=secret`, so the path can go. This PR gates it behind `FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE` and starts the standard graduation toward removal.