### PR TITLE
mz725: fix panics on malformed OCI Config and /etc/group

### DIFF
--- a/integration/config.go
+++ b/integration/config.go
@@ -29,6 +29,7 @@ type integrationTestConfig struct {
 	onbuildCopyImage        string
 	hardlinkBaseImage       string
 	hijackBaseImage         string
+	malformedOCIImage       string
 	nvidiaOperatorBaseImage string
 	serviceAccount          string
 	dockerMajorVersion      int

--- a/integration/dockerfiles/Dockerfile_test_issue_mz725
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz725
@@ -1,0 +1,19 @@
+ARG IMAGE_REPO
+
+# Stage `base` is pushed by test setup (`docker build --target=base`); a Go
+# helper then mutates its OCI Config (Env entry without `=`, relative
+# WorkingDir, User=root) and pushes back to the same tag. The result is a
+# malformed-but-valid image — unproducible by docker/podman/buildah but
+# reachable from any hand-crafted OCI producer.
+FROM busybox AS base
+RUN echo 'single' >> /etc/group
+
+FROM ${IMAGE_REPO}malformed-oci:latest
+# mz727: UpdateConfigEnv index-OOB on a Config.Env entry without `=`.
+ENV NEW=val
+# mz726: ToAbsPath assertion when Config.WorkingDir is relative.
+WORKDIR sub
+# mz725: ReplacementEnvs nil-deref on a Config.Env entry without `=`.
+USER root
+# mz728: SyscallCredentials reads /etc/group; no-CGO parser OOBs on `single`.
+RUN id

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1325,11 +1325,8 @@ func initIntegrationTestConfig() *integrationTestConfig {
 	c.onbuildCopyImage = c.imageRepo + "onbuild-copy:latest"
 	c.hardlinkBaseImage = c.imageRepo + "hardlink-base:latest"
 	c.hijackBaseImage = c.imageRepo + "hijack:latest"
-<<<<<<< HEAD
-	c.nvidiaOperatorBaseImage = c.imageRepo + "nvidia-operator-base:latest"
-=======
 	c.malformedOCIImage = c.imageRepo + "malformed-oci:latest"
->>>>>>> f56c642a5 (mz725: integration test for malformed image)
+	c.nvidiaOperatorBaseImage = c.imageRepo + "nvidia-operator-base:latest"
 	return &c
 }
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -173,6 +173,9 @@ func buildRequiredImages() error {
 		name:    "Building hijack base image",
 		command: []string{"docker", "build", "--push", "-t", config.hijackBaseImage, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz560", "--target", "base", "."},
 	}, {
+		name:    "Building malformed-oci base image",
+		command: []string{"docker", "build", "--push", "-t", config.malformedOCIImage, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz725", "--target", "base", "."},
+	}, {
 		name:    "Building mz753 base image",
 		command: []string{"docker", "build", "--push", "-t", config.nvidiaOperatorBaseImage, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz753", "--target", "base", "."},
 	}, {
@@ -190,6 +193,11 @@ func buildRequiredImages() error {
 
 	maliciousRef := strings.ToLower(config.imageRepo + "path-traversal-malicious:latest")
 	err := pushMaliciousPathTraversalImage(maliciousRef)
+	if err != nil {
+		return err
+	}
+
+	err = mutateMalformedOCIImageConfig(config.malformedOCIImage)
 	if err != nil {
 		return err
 	}
@@ -727,6 +735,38 @@ func pushMaliciousPathTraversalImage(imageRef string) error {
 	}
 	if err := remote.Write(ref, img, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
 		return fmt.Errorf("pushing malicious image to %s: %v", imageRef, err)
+	}
+	return nil
+}
+
+// mutateMalformedOCIImageConfig mutest a base image
+// in a way that is impossible with regular build tools
+func mutateMalformedOCIImageConfig(imageRef string) error {
+	ref, err := name.ParseReference(imageRef, name.WeakValidation)
+	if err != nil {
+		return fmt.Errorf("parsing image ref %s: %v", imageRef, err)
+	}
+	base, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return fmt.Errorf("pulling malformed-oci base image: %v", err)
+	}
+
+	cf, err := base.ConfigFile()
+	if err != nil {
+		return fmt.Errorf("reading malformed-oci base image config: %v", err)
+	}
+	cf = cf.DeepCopy()
+	cf.Config.Env = []string{"GOOD=value", "MALFORMED_NO_EQUALS"}
+	cf.Config.WorkingDir = "relwd"
+	cf.Config.User = "root"
+	img, err := mutate.ConfigFile(base, cf)
+	if err != nil {
+		return fmt.Errorf("mutating malformed-oci image config: %v", err)
+	}
+
+	err = remote.Write(ref, img, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return fmt.Errorf("pushing mutated malformed-oci image to %s: %v", imageRef, err)
 	}
 	return nil
 }
@@ -1285,7 +1325,11 @@ func initIntegrationTestConfig() *integrationTestConfig {
 	c.onbuildCopyImage = c.imageRepo + "onbuild-copy:latest"
 	c.hardlinkBaseImage = c.imageRepo + "hardlink-base:latest"
 	c.hijackBaseImage = c.imageRepo + "hijack:latest"
+<<<<<<< HEAD
 	c.nvidiaOperatorBaseImage = c.imageRepo + "nvidia-operator-base:latest"
+=======
+	c.malformedOCIImage = c.imageRepo + "malformed-oci:latest"
+>>>>>>> f56c642a5 (mz725: integration test for malformed image)
 	return &c
 }
 

--- a/pkg/commands/workdir.go
+++ b/pkg/commands/workdir.go
@@ -41,11 +41,10 @@ func ToAbsPath(path string, workdir string) string {
 	if filepath.IsAbs(path) {
 		result = path
 	} else {
-		if workdir != "" {
-			result = filepath.Join(workdir, path)
-		} else {
-			result = filepath.Join("/", path)
+		if !filepath.IsAbs(workdir) {
+			workdir = "/" + workdir
 		}
+		result = filepath.Join(workdir, path)
 	}
 	util.Assert("workdir.abs-path", filepath.IsAbs(result), "ToAbsPath must return an absolute path, got %q (path=%q, workdir=%q)", result, path, workdir)
 	return result

--- a/pkg/dockerfile/buildargs.go
+++ b/pkg/dockerfile/buildargs.go
@@ -103,7 +103,11 @@ func (b *BuildArgs) ReplacementEnvs(envs []string) []string {
 	}
 	result := make([]string, 0, len(merged))
 	for key, val := range merged {
-		result = append(result, fmt.Sprintf("%s=%s", key, *val))
+		if val == nil {
+			result = append(result, key)
+		} else {
+			result = append(result, fmt.Sprintf("%s=%s", key, *val))
+		}
 	}
 	// Args can add keys but must not remove existing env keys.
 	util.Assert("buildargs.replacement-envs.min-size", nenvs <= len(result), "ReplacementEnvs: result (%d) is smaller than de-duplicated envs (%d)", len(result), nenvs)

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -317,10 +317,10 @@ func UpdateConfigEnv(envVars []instructions.KeyValuePair, config *v1.Config, rep
 	// First, convert config.Env array to []instruction.KeyValuePair
 	var kvps []instructions.KeyValuePair
 	for _, env := range config.Env {
-		entry := strings.SplitN(env, "=", 2)
+		key, value, _ := strings.Cut(env, "=")
 		kvps = append(kvps, instructions.KeyValuePair{
-			Key:   entry[0],
-			Value: entry[1],
+			Key:   key,
+			Value: value,
 		})
 	}
 	// Iterate through new environment variables, and replace existing keys

--- a/pkg/util/groupids_fallback.go
+++ b/pkg/util/groupids_fallback.go
@@ -87,6 +87,9 @@ func localGroups(r io.Reader) []*group {
 
 		// wheel:*:0:root,anotherGrp
 		parts := strings.SplitN(string(line), ":", 4)
+		if len(parts) < 4 {
+			continue
+		}
 		if _, err := strconv.Atoi(parts[2]); err != nil {
 			continue
 		}


### PR DESCRIPTION
Closes #725, closes #726, closes #727, closes #728.

Four kaniko panic sites reachable from any malformed-but-valid OCI base image. The integration fixture `Dockerfile_test_issue_mz725` plants all four malformations in one image and asserts kaniko builds without panic.

| Issue | Site | Trigger | Fix |
|---|---|---|---|
| #725 | `BuildArgs.ReplacementEnvs` | base `Config.Env` entry without `=` | nil-safe loop: `val == nil` → append key only |
| #727 | `util.UpdateConfigEnv` | base `Config.Env` entry without `=` | use `strings.Cut` so missing value defaults to `""` |
| #726 | `commands.ToAbsPath` | base `Config.WorkingDir` is relative | prepend `/` to a relative workdir before joining |
| #728 | `util.localGroups` (no-CGO) | `/etc/group` line with fewer than three colons | `continue` when `len(parts) < 4` |