### PR TITLE
mz745: parse --custom-platform variant into Architecture and Variant

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1338,6 +1338,36 @@ func TestAlpineTLS(t *testing.T) {
 	}
 }
 
+// mz745: in kaniko v1.27.0 --custom-platform folds an architecture variant like linux/arm/v7
+// into Architecture="arm/v7". diffoci ignores the config platform fields, so rather than a
+// docker diff we reuse the cross_compile dockerfile and assert OS/Architecture/Variant directly.
+func TestCustomPlatformVariant(t *testing.T) {
+	_, ex, _, _ := runtime.Caller(0)
+	cwd := filepath.Dir(ex)
+	kanikoImage := GetKanikoImage(config.imageRepo, "issue_mz745")
+	_, err := buildKanikoImage(
+		t.Logf,
+		dockerfilesPath,
+		"Dockerfile_test_cross_compile",
+		nil,
+		[]string{"--custom-platform=linux/arm/v7", "-c", buildContextPath},
+		kanikoImage,
+		cwd,
+		"", nil, config.serviceAccount, false, "", "",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := getImageConfig(kanikoImage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testutil.CheckDeepEqual(t, "linux", cfg.OS)
+	testutil.CheckDeepEqual(t, "arm", cfg.Architecture)
+	testutil.CheckDeepEqual(t, "v7", cfg.Variant)
+}
+
 // containerDiff compares the container images image1 and image2.
 func containerDiff(t *testing.T, image1, image2 string, flags ...string) {
 	// workaround for container-diff OCI issue https://github.com/GoogleContainerTools/container-diff/issues/389

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -1130,12 +1130,14 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 			configFile.OS = runtime.GOOS
 			configFile.Architecture = runtime.GOARCH
 		} else {
-			os, arch, ok := strings.Cut(opts.CustomPlatform, "/")
-			if !ok {
-				return nil, fmt.Errorf("invalid platform format %q, expected os/arch", opts.CustomPlatform)
+			platform, err := v1.ParsePlatform(opts.CustomPlatform)
+			if err != nil {
+				return nil, fmt.Errorf("invalid platform %q: %w", opts.CustomPlatform, err)
 			}
-			configFile.OS = os
-			configFile.Architecture = arch
+			configFile.OS = platform.OS
+			configFile.Architecture = platform.Architecture
+			configFile.Variant = platform.Variant
+			configFile.OSVersion = platform.OSVersion
 		}
 		sourceImage, err = mutate.ConfigFile(sourceImage, configFile)
 		if err != nil {


### PR DESCRIPTION
Closes #745.

`--custom-platform` was parsed in `build.go` with `strings.Cut` on the first `/`, which for a variant-bearing platform like `linux/arm/v7` folded the variant into the architecture (`Architecture: "arm/v7"`) instead of separating it out. Since the variant is never overwritten, an arm/v7 base image (whose config already carries `Variant: v7`) ended up with the duplicated `linux/arm/v7/v7` triplet. This regressed in v1.27.0 when the parsing switched from `strings.Split[1]` to `strings.Cut`. The fix reuses `v1.ParsePlatform` (the parser already used for validation and for base-image resolution) so the written config and the predefined build args agree on the platform.
