### PR TITLE
Handle NVIDIA GPU operator bind-mounts during layer extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `FF_KANIKO_CACHE_LOOKAHEAD`](#flag-ff_kaniko_cache_lookahead)
       - [Flag `FF_KANIKO_CACHE_PROBE_AFTER_MISS`](#flag-ff_kaniko_cache_probe_after_miss)
       - [Flag `FF_KANIKO_WARMER_CACHE_LOCK`](#flag-ff_kaniko_warmer_cache_lock)
+      - [Flag `FF_KANIKO_PRESERVE_MOUNTED_PATHS`](#flag-ff_kaniko_preserve_mounted_paths)
     - [Debug Image](#debug-image)
   - [Security](#security)
     - [Verifying Signed Kaniko Images](#verifying-signed-kaniko-images)
@@ -1224,6 +1225,12 @@ Defaults to `false`.
 Multiple warmer processes sharing a cache volume can race on the final rename to `cacheDir/<digest>`. With [`FF_KANIKO_OCI_WARMER`](#flag-ff_kaniko_oci_warmer) the rename fails with `ENOTEMPTY` and the loser exits non-zero.
 Set this flag to `true` to serialize the recheck + rename via a per-digest `flock(2)` on `cacheDir/.warmer-locks/<digest>.lock`.
 Defaults to `false`.
+Becomes default in `v1.28.0`.
+
+#### Flag `FF_KANIKO_PRESERVE_MOUNTED_PATHS`
+
+When a container runtime bind-mounts files read-only into the build container — as the NVIDIA GPU operator does with driver artifacts (`nvidia-smi`, `libnvidia*`, firmware blobs) on GPU nodes — and a base image layer ships a directory along that mount path as a symlink, kaniko `os.RemoveAll`s the directory while unpacking to make way for the symlink. The recursive remove hits the read-only bind mount and the build fails with `unlinkat ...: device or resource busy`.
+Set this flag to `true` to skip removing a directory that contains a mounted (ignored) path: its other contents are still cleared, but the mount is preserved and the conflicting layer entry is left in place, matching how `DeleteFilesystem` already treats mounts. Defaults to `false`.
 Becomes default in `v1.28.0`.
 
 ### Assertion Overrides

--- a/integration/config.go
+++ b/integration/config.go
@@ -23,16 +23,17 @@ import (
 )
 
 type integrationTestConfig struct {
-	gcsBucket          string
-	imageRepo          string
-	onbuildBaseImage   string
-	onbuildCopyImage   string
-	hardlinkBaseImage  string
-	hijackBaseImage    string
-	serviceAccount     string
-	dockerMajorVersion int
-	gcsClient          *storage.Client
-	dockerfilesPattern string
+	gcsBucket               string
+	imageRepo               string
+	onbuildBaseImage        string
+	onbuildCopyImage        string
+	hardlinkBaseImage       string
+	hijackBaseImage         string
+	nvidiaOperatorBaseImage string
+	serviceAccount          string
+	dockerMajorVersion      int
+	gcsClient               *storage.Client
+	dockerfilesPattern      string
 }
 
 const gcrRepoPrefix string = "gcr.io/"

--- a/integration/dockerfiles/Dockerfile_test_issue_mz753
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz753
@@ -1,0 +1,13 @@
+# mz753: through kaniko v1.27.x, builds aborted with "device or resource busy" when
+# a container runtime (e.g. the NVIDIA device plugin) bind-mounts driver files
+# read-only into the build container under a directory the base image replaces with
+# a symlink. The harness reproduces it by mounting a file at /opt/driver/lib.so so
+# /opt/driver is a real directory, while the base stage below ships /opt/driver as a
+# symlink: unpacking it, kaniko removed the directory to make way for the symlink and
+# hit the busy mount. The mounted path must be preserved instead.
+ARG IMAGE_REPO
+FROM busybox AS base
+RUN mkdir -p /opt/real && ln -s /opt/real /opt/driver
+
+FROM ${IMAGE_REPO}nvidia-operator-base:latest
+RUN echo mz753

--- a/integration/images.go
+++ b/integration/images.go
@@ -122,6 +122,7 @@ var KanikoEnv = []string{
 	"FF_KANIKO_RUN_MOUNT_BIND=1",
 	"FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY=1",
 	"FF_KANIKO_CACHE_LOOKAHEAD=1",
+	"FF_KANIKO_PRESERVE_MOUNTED_PATHS=1",
 	"KANIKO_PRINT_PLAN=1",
 }
 
@@ -876,6 +877,12 @@ func (d *DockerFileBuilder) buildRelativePathsImage(logf logger, imageRepo, dock
 	return nil
 }
 
+var extraDockerRunFlags = map[string]func(contextDir string) []string{
+	"Dockerfile_test_issue_mz753": func(ctx string) []string {
+		return []string{"-v", filepath.Join(ctx, "testdata/Dockerfile.trivial") + ":/opt/driver/lib.so:ro"}
+	},
+}
+
 func buildKanikoImage(
 	logf logger,
 	dockerfilesPath string,
@@ -955,6 +962,10 @@ func buildKanikoImage(
 	if tlsCACert != "" {
 		dockerRunFlags = append(dockerRunFlags,
 			"-v", tlsCACert+":/kaniko/ssl/certs/test-registry-ca.crt:ro")
+	}
+
+	if fn, ok := extraDockerRunFlags[dockerfile]; ok {
+		dockerRunFlags = append(dockerRunFlags, fn(contextDir)...)
 	}
 
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -173,6 +173,9 @@ func buildRequiredImages() error {
 		name:    "Building hijack base image",
 		command: []string{"docker", "build", "--push", "-t", config.hijackBaseImage, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz560", "--target", "base", "."},
 	}, {
+		name:    "Building mz753 base image",
+		command: []string{"docker", "build", "--push", "-t", config.nvidiaOperatorBaseImage, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz753", "--target", "base", "."},
+	}, {
 		name:    "Building kaniko image based on alpine",
 		command: []string{"docker", "build", coverArg, "-t", AlpineImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-alpine", ".."},
 	}}
@@ -1278,6 +1281,7 @@ func initIntegrationTestConfig() *integrationTestConfig {
 	c.onbuildCopyImage = c.imageRepo + "onbuild-copy:latest"
 	c.hardlinkBaseImage = c.imageRepo + "hardlink-base:latest"
 	c.hijackBaseImage = c.imageRepo + "hijack:latest"
+	c.nvidiaOperatorBaseImage = c.imageRepo + "nvidia-operator-base:latest"
 	return &c
 }
 

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -279,6 +279,39 @@ func childDirInIgnoreList(path string) bool {
 	return false
 }
 
+func removeAllSkipIgnored(path string) (skip bool, err error) {
+	if !config.EnvBool("FF_KANIKO_PRESERVE_MOUNTED_PATHS") || !childDirInIgnoreList(path) {
+		return false, os.RemoveAll(path)
+	}
+	logrus.Debugf("Not removing %s, as it contains an ignored path", path)
+	err = filepath.WalkDir(path, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if p == path {
+			return nil
+		}
+		if CheckCleanedPathAgainstIgnoreList(p) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if childDirInIgnoreList(p) {
+			return nil
+		}
+		rmErr := os.RemoveAll(p)
+		if rmErr != nil {
+			return rmErr
+		}
+		if d.IsDir() {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	return true, err
+}
+
 // UnTar returns a list of files that have been extracted from the tar archive at r to the path at dest
 func UnTar(r io.Reader, dest string) ([]string, error) {
 	var extractedFiles []string
@@ -339,8 +372,12 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 		// Check if something already exists at path (symlinks etc.)
 		// If so, delete it
 		if FilepathExists(path) {
-			if err := os.RemoveAll(path); err != nil {
+			skip, err := removeAllSkipIgnored(path)
+			if err != nil {
 				return fmt.Errorf("error removing %s to make way for new file: %w", path, err)
+			}
+			if skip {
+				return nil
 			}
 		}
 
@@ -397,8 +434,12 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 		// Check if something already exists at path
 		// If so, delete it
 		if FilepathExists(path) {
-			if err := os.RemoveAll(path); err != nil {
+			skip, err := removeAllSkipIgnored(path)
+			if err != nil {
 				return fmt.Errorf("error removing %s to make way for new link: %w", hdr.Name, err)
+			}
+			if skip {
+				return nil
 			}
 		}
 		cleanedLink := filepath.Clean(hdr.Linkname)
@@ -419,8 +460,12 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 		// Check if something already exists at path
 		// If so, delete it
 		if FilepathExists(path) {
-			if err := os.RemoveAll(path); err != nil {
+			skip, err := removeAllSkipIgnored(path)
+			if err != nil {
 				return fmt.Errorf("error removing %s to make way for new symlink: %w", hdr.Name, err)
+			}
+			if skip {
+				return nil
 			}
 		}
 		if err := os.Symlink(hdr.Linkname, path); err != nil {


### PR DESCRIPTION
Fixes #753. Also fixes the long-standing upstream report GoogleContainerTools/kaniko#3006.

When a container runtime bind-mounts files read-only into the build container — as the NVIDIA GPU operator does with driver artifacts on GPU nodes — kaniko could abort with `device or resource busy` while unpacking the base image.

`ExtractFile` removes whatever already exists at a path to make way for a new file, link, or symlink, but unlike `DeleteFilesystem` it never checked whether that path held an ignored (mounted) descendant. So `os.RemoveAll` recursed into the mount and the `unlinkat` failed the build. The ignore check it had only guarded the entry being added, not the directory destroyed to make room for it — which is why pointing `--ignore-path` at the mount didn't help.

The fix gives extraction the same `childDirInIgnoreList` awareness the cleanup path already has: when the directory being replaced holds a mounted or ignored path, kaniko leaves it in place and continues. Gated behind `FF_KANIKO_PRESERVE_MOUNTED_PATHS`.