### PR TITLE
mz334: infer cross-stage cache key - part 3

### DIFF
--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -22,12 +22,15 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/osscontainertools/kaniko/cmd/executor/cmd"
 	testissuemz195 "github.com/osscontainertools/kaniko/golden/testdata/test_issue_mz195"
 	testissuemz333 "github.com/osscontainertools/kaniko/golden/testdata/test_issue_mz333"
@@ -45,17 +48,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// mirrors pkg/executor/push.go
+const cachePointerLabel = "kaniko.cache.pointer-target"
+
 type fakeLayerCache struct {
 	cachedKeys []string
 }
 
 func (f *fakeLayerCache) RetrieveLayer(key string) (v1.Image, error) {
-	for _, k := range f.cachedKeys {
-		if k == key {
-			return nil, nil
-		}
+	if !slices.Contains(f.cachedKeys, key) {
+		return nil, errors.New("could not find layer")
 	}
-	return nil, errors.New("could not find layer")
+	cf := &v1.ConfigFile{}
+	cf.Config.Labels = map[string]string{cachePointerLabel: key}
+	return mutate.ConfigFile(empty.Image, cf)
 }
 
 func renderCommand(env map[string]string, args []string) string {

--- a/golden/testdata/test_issue_mz334/plans/inferred
+++ b/golden/testdata/test_issue_mz334/plans/inferred
@@ -1,0 +1,32 @@
+FROM busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d AS first
+UNPACK busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
+CACHE HIT: e6201ef5c7fab656a2bb0615888d02f181fc7677dbeaaace249484bbdbf79106
+RUN touch /blubb
+SAVE STAGE /kaniko/stages/0
+SAVE FILES [/blubb] /kaniko/deps/0
+CLEAN
+
+FROM first AS second
+UNPACK /kaniko/stages/0
+CACHE HIT: 09e840ef4fefde5c634154ead19bbff9cfa881073b77cb3c85a400fe215bd518
+RUN touch /bla
+SAVE STAGE /kaniko/stages/1
+CLEAN
+
+FROM second AS third
+UNPACK /kaniko/stages/1
+CACHE HIT: 26d0935bb7ffd5e1f69ecc89608706dfda254c8e9e217f8ccf171d6f3078e0d1
+RUN touch /bli
+SAVE FILES [/bli] /kaniko/deps/2
+CLEAN
+
+FROM second AS final
+UNPACK /kaniko/stages/1
+CACHE REDIRECT HIT: c8dcad366cc9096323cf121a96ee9ae0437840e8e324cb3c82e457fef8fd9a0f
+CACHE HIT: 92ece401b53237b1cb1a1a76f4b6c5a8985786382640c449926478a0c906c367
+COPY --from=first /blubb /blubb
+CACHE REDIRECT HIT: ac12aaca9dc32e6f46dbe8a81c7320d9183c47afc03864a06aab26162e3d839e
+CACHE HIT: 504aa65388888b60fc488199c324b1055d6193dc33f7a93aee592e77345f062a
+COPY --from=third /bli /bli
+CACHE HIT: 8a2e7b51565c0ae062ec5289398fcd9c36e40b6fe7da39051fb2b94d0da06c89
+RUN ls -lah /blubb

--- a/golden/testdata/test_issue_mz334/test.go
+++ b/golden/testdata/test_issue_mz334/test.go
@@ -23,5 +23,23 @@ var Tests = types.GoldenTests{
 			},
 			Plan: "cached",
 		},
+		{
+			Args: []string{"--no-push", "--cache", "--cache-copy-layers"},
+			Env: map[string]string{
+				"FF_KANIKO_CACHE_LOOKAHEAD":             "1",
+				"FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY": "1",
+			},
+			CachedKeys: []string{
+				"e6201ef5c7fab656a2bb0615888d02f181fc7677dbeaaace249484bbdbf79106",
+				"09e840ef4fefde5c634154ead19bbff9cfa881073b77cb3c85a400fe215bd518",
+				"26d0935bb7ffd5e1f69ecc89608706dfda254c8e9e217f8ccf171d6f3078e0d1",
+				"c8dcad366cc9096323cf121a96ee9ae0437840e8e324cb3c82e457fef8fd9a0f",
+				"ac12aaca9dc32e6f46dbe8a81c7320d9183c47afc03864a06aab26162e3d839e",
+				"92ece401b53237b1cb1a1a76f4b6c5a8985786382640c449926478a0c906c367",
+				"504aa65388888b60fc488199c324b1055d6193dc33f7a93aee592e77345f062a",
+				"8a2e7b51565c0ae062ec5289398fcd9c36e40b6fe7da39051fb2b94d0da06c89",
+			},
+			Plan: "inferred",
+		},
 	},
 }

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -320,52 +320,73 @@ func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, 
 		}
 		if opts.Cache && keyValid {
 			// During precompute (no file context): can't hash COPY --from contents.
-			if !hasContext {
-				if copyCmd, ok2 := commands.CastAbstractCopyCommand(command); ok2 && copyCmd.From() != "" {
+			copyCmd, isCopy := commands.CastAbstractCopyCommand(command)
+			if !hasContext && isCopy && copyCmd.From() != "" {
+				inferred := false
+				if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers {
+					inferredKey, err := populateCompositeKey(command, nil, compositeKey, args, cfg.Env, fileContext, stageFinalCacheKeys, externalImageDigests)
+					if err == nil {
+						inferredCK, err := inferredKey.Hash()
+						if err != nil {
+							return "", ci, err
+						}
+						ci.redirectKeys[i] = inferredCK
+						contentKey, err := redirectCacheKey(inferredKey, layerCache)
+						if err != nil {
+							return "", ci, err
+						}
+						if contentKey != nil {
+							compositeKey = *contentKey
+							inferred = true
+							ci.redirectHits[i] = true
+						}
+					}
+				}
+				if !inferred {
 					stopCache = true
 					keyValid = false
 					finalCacheKey = ""
 					continue // COPY is never MetadataOnly, safe to skip
 				}
-			}
+			} else {
+				files, err := command.FilesUsedFromContext(&cfg, args)
+				if err != nil {
+					return "", ci, fmt.Errorf("failed to get files used from context: %w", err)
+				}
 
-			files, err := command.FilesUsedFromContext(&cfg, args)
-			if err != nil {
-				return "", ci, fmt.Errorf("failed to get files used from context: %w", err)
-			}
+				prevCompositeKey := compositeKey.Clone()
+				compositeKey, err = populateCompositeKey(command, files, compositeKey, args, cfg.Env, fileContext, nil, nil)
+				if err != nil {
+					return "", ci, err
+				}
 
-			prevCompositeKey := compositeKey.Clone()
-			compositeKey, err = populateCompositeKey(command, files, compositeKey, args, cfg.Env, fileContext, nil, nil)
-			if err != nil {
-				return "", ci, err
-			}
-
-			// mz334: assert the inferred key pointer resolves to the same content key.
-			if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers {
-				inferredKey, err := populateCompositeKey(command, nil, prevCompositeKey, args, cfg.Env, fileContext, stageFinalCacheKeys, externalImageDigests)
-				if err == nil {
-					inferredCK, err := inferredKey.Hash()
-					if err != nil {
-						return "", ci, err
-					}
-					ci.redirectKeys[i] = inferredCK
-					contentKey, err := redirectCacheKey(inferredKey, layerCache)
-					if err != nil {
-						return "", ci, err
-					}
-					if contentKey != nil {
-						ick, err := contentKey.Hash()
+				// mz334: assert the inferred key pointer resolves to the same content key.
+				if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers {
+					inferredKey, err := populateCompositeKey(command, nil, prevCompositeKey, args, cfg.Env, fileContext, stageFinalCacheKeys, externalImageDigests)
+					if err == nil {
+						inferredCK, err := inferredKey.Hash()
 						if err != nil {
 							return "", ci, err
 						}
-						ck, err := compositeKey.Hash()
+						ci.redirectKeys[i] = inferredCK
+						contentKey, err := redirectCacheKey(inferredKey, layerCache)
 						if err != nil {
 							return "", ci, err
 						}
-						util.Assert("executor.compositekey.key-match", ick == ck, "pointer inferred content key %v does not match the computed content key %v", ick, ck)
-						// mz334: log when the inferred key produced the hit (integration test observability only).
-						logrus.Infof("Cache hit via inferred cross-stage key for cmd: %s", command.String())
-						ci.redirectHits[i] = true
+						if contentKey != nil {
+							ick, err := contentKey.Hash()
+							if err != nil {
+								return "", ci, err
+							}
+							ck, err := compositeKey.Hash()
+							if err != nil {
+								return "", ci, err
+							}
+							util.Assert("executor.compositekey.key-match", ick == ck, "pointer inferred content key %v does not match the computed content key %v", ick, ck)
+							// mz334: log when the inferred key produced the hit (integration test observability only).
+							logrus.Infof("Cache hit via inferred cross-stage key for cmd: %s", command.String())
+							ci.redirectHits[i] = true
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Activate the infer cache key mechanism. #618 introduced the inferred cross-stage key as an assert-only check, and #741 extended it to external COPY --from, but neither acts on the key yet. I held off until the golden tests could show real cache hits. #674 added cache-key support to the golden tests, so that is now possible, and the mz334 plan shows the hits.

Until now the lookahead precompute pass gave up on every COPY --from, because it can't hash the copied files without the source stage materialized. Now it resolves the redirect pointer that the build pass writes, derives the copy layer's key from the source stage's already-known cache key, and continues the chain without unpacking the source. The build pass stays the ground truth and still asserts the inferred key matches the file-hashed one.