### PR TITLE
mz775: skip re-gzip on media-type relabel

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE`](#flag-ff_kaniko_deprecate_inter_stage_restore)
       - [Flag `FF_KANIKO_SCOPED_DOCKERIGNORE`](#flag-ff_kaniko_scoped_dockerignore)
       - [Flag `FF_KANIKO_COPY_CACHEKEY_FOLD_ARGS`](#flag-ff_kaniko_copy_cachekey_fold_args)
+      - [Flag `FF_KANIKO_SKIP_RELABEL_RECOMPRESS`](#flag-ff_kaniko_skip_relabel_recompress)
     - [Assertion Overrides](#assertion-overrides)
     - [Debug Image](#debug-image)
   - [Security](#security)
@@ -1305,6 +1306,13 @@ Currently no plans to activate.
 
 A `COPY` or `ADD` layer cache key is built from the raw instruction text, so build args and env expanded in the instruction (for example `COPY foo /$A/foo`) do not enter the key. With `--cache-copy-layers` a build that only changes such a variable hits the layer cached for a different resolved value and serves a stale layer at the wrong path.
 Set this flag to `true` to fold the resolved build args and env into the cache key whenever a `COPY` or `ADD` instruction references a variable.
+Defaults to `false`.
+Becomes default in `v1.29.0`.
+
+#### Flag `FF_KANIKO_SKIP_RELABEL_RECOMPRESS`
+
+When a cached layer is reused in an image of a different media-type vendor, kaniko not only relabels the layer but re-gzips it too. if the compression is unchanged, the re-encoded blob is byte-identical to the original.
+Set this flag to `true` to skip the unecessary re-compression and serve the relabeled already-compressed blob.
 Defaults to `false`.
 Becomes default in `v1.29.0`.
 

--- a/integration/dockerfiles/Dockerfile_test_issue_mz775
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz775
@@ -1,0 +1,26 @@
+# mz775: saving this stage deadlocks in saveStageAsTarball.
+#
+# The stage ends up with many layers that share one compressed digest, so the
+# OCI layout writer fans out a goroutine per manifest entry and they all write
+# that single blob at once, each fetching it through one shared pullLimiter. The
+# first goroutine to rename the blob into place wins. The rest then find it
+# already on disk and return early from writeBlob, closing the gzip pipe without
+# reading it to the end. internal/gzip's writer goroutine fails its final flush
+# on the closed pipe and returns without closing the reader it wraps, the reader
+# that holds the pullLimiter token, so the token leaks. Once every token has
+# leaked the remaining goroutines block forever acquiring one and the save never
+# returns.
+FROM debian:12.10 AS base
+RUN echo 1 >/dev/null
+RUN echo 2 >/dev/null
+RUN echo 3 >/dev/null
+RUN echo 4 >/dev/null
+RUN echo 5 >/dev/null
+RUN echo 6 >/dev/null
+RUN echo 7 >/dev/null
+RUN echo 8 >/dev/null
+RUN echo 9 >/dev/null
+RUN echo 10 >/dev/null
+
+FROM base
+RUN echo done >/dev/null

--- a/integration/dockerfiles/Dockerfile_test_issue_mz775
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz775
@@ -1,15 +1,13 @@
-# mz775: saving this stage deadlocks in saveStageAsTarball.
+# mz775: in v1.27.6 saving the base stage deadlocks in when saving as ocilayout.
 #
-# The stage ends up with many layers that share one compressed digest, so the
-# OCI layout writer fans out a goroutine per manifest entry and they all write
-# that single blob at once, each fetching it through one shared pullLimiter. The
-# first goroutine to rename the blob into place wins. The rest then find it
-# already on disk and return early from writeBlob, closing the gzip pipe without
-# reading it to the end. internal/gzip's writer goroutine fails its final flush
-# on the closed pipe and returns without closing the reader it wraps, the reader
-# that holds the pullLimiter token, so the token leaks. Once every token has
-# leaked the remaining goroutines block forever acquiring one and the save never
-# returns.
+# Due to the way we construct the image below, the stage ends up with many layers
+# that share the same compressed digest. The OCI layout writer fans out a goroutine
+# per manifest entry and they all write that single blob at once,
+# The first goroutine to rename the blob into place wins. The rest then find it already on disk
+# and return early, closing the gzip pipe without reading it to the end.
+# internal/gzip's writer goroutine fails its final flush on the closed pipe and returns
+# without closing the reader it wraps, the reader that holds the pullLimiter token, so the token leaks.
+# Once every token has leaked the remaining goroutines block forever acquiring one and the save never returns.
 FROM debian:12.10 AS base
 RUN echo 1 >/dev/null
 RUN echo 2 >/dev/null

--- a/integration/images.go
+++ b/integration/images.go
@@ -99,6 +99,7 @@ var envsMap = map[string][]string{
 	"Dockerfile_test_issue_1039":                 {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_2066":                 {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_1837":                 {"FF_KANIKO_SQUASH_STAGES=0"},
+	"Dockerfile_test_issue_mz775":                {"FF_KANIKO_SQUASH_STAGES=0", "FF_KANIKO_CACHE_LOOKAHEAD=0"},
 	"Dockerfile_test_issue_mz782":                {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_mz789":                {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_cg188":                {"SECRET=blubb"},
@@ -190,6 +191,7 @@ var executorImages = map[string]string{
 // Arguments to build Dockerfiles with when building with kaniko
 var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_add":                    {"--single-snapshot"},
+	"Dockerfile_test_issue_mz775":            {"--compressed-caching=false"},
 	"Dockerfile_test_issue_mz621":            {"--single-snapshot"},
 	"Dockerfile_test_run_new":                {"--use-new-run=true"},
 	"Dockerfile_test_run_redo":               {"--snapshot-mode=redo"},
@@ -495,6 +497,7 @@ func NewDockerFileBuilder() *DockerFileBuilder {
 		"Dockerfile_test_issue_mz655":   {},
 		"Dockerfile_test_issue_mz774":   {},
 		"Dockerfile_test_issue_mz782":   {},
+		"Dockerfile_test_issue_mz775":   {},
 		"Dockerfile_test_issue_mz793":   {},
 	}
 	d.TestOCICacheDockerfiles = map[string]struct{}{

--- a/integration/images.go
+++ b/integration/images.go
@@ -496,8 +496,8 @@ func NewDockerFileBuilder() *DockerFileBuilder {
 		"Dockerfile_test_issue_mz334":   {},
 		"Dockerfile_test_issue_mz655":   {},
 		"Dockerfile_test_issue_mz774":   {},
-		"Dockerfile_test_issue_mz782":   {},
 		"Dockerfile_test_issue_mz775":   {},
+		"Dockerfile_test_issue_mz782":   {},
 		"Dockerfile_test_issue_mz793":   {},
 	}
 	d.TestOCICacheDockerfiles = map[string]struct{}{

--- a/integration/images.go
+++ b/integration/images.go
@@ -99,7 +99,7 @@ var envsMap = map[string][]string{
 	"Dockerfile_test_issue_1039":                 {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_2066":                 {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_1837":                 {"FF_KANIKO_SQUASH_STAGES=0"},
-	"Dockerfile_test_issue_mz775":                {"FF_KANIKO_SQUASH_STAGES=0", "FF_KANIKO_CACHE_LOOKAHEAD=0"},
+	"Dockerfile_test_issue_mz775":                {"FF_KANIKO_SQUASH_STAGES=0", "FF_KANIKO_CACHE_LOOKAHEAD=0", "FF_KANIKO_SKIP_RELABEL_RECOMPRESS=1"},
 	"Dockerfile_test_issue_mz782":                {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_mz789":                {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_cg188":                {"SECRET=blubb"},

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -771,6 +771,17 @@ func convertMediaType(mt types.MediaType) types.MediaType {
 	}
 }
 
+func layerCompression(mt types.MediaType) config.Compression {
+	switch {
+	case strings.HasSuffix(string(mt), "zstd"):
+		return config.ZStd
+	case strings.HasSuffix(string(mt), "gzip"):
+		return config.GZip
+	default:
+		return ""
+	}
+}
+
 func convertLayerMediaType(layer v1.Layer, image v1.Image, opts *config.KanikoOptions) (v1.Layer, error) {
 	layerMediaType, err := layer.MediaType()
 	if err != nil {
@@ -794,6 +805,24 @@ func convertLayerMediaType(layer v1.Layer, image v1.Image, opts *config.KanikoOp
 		layerOpts = append(layerOpts, tarball.WithMediaType(targetMediaType))
 
 		if targetMediaType != "" {
+			srcCompression := layerCompression(layerMediaType)
+			dstCompression := layerCompression(targetMediaType)
+			if config.EnvBool("FF_KANIKO_SKIP_RELABEL_RECOMPRESS") && srcCompression != "" && srcCompression == dstCompression {
+				relabeled, err := tarball.LayerFromOpener(layer.Compressed, layerOpts...)
+				if err != nil {
+					return nil, err
+				}
+				rd, err := relabeled.Digest()
+				if err != nil {
+					return nil, err
+				}
+				ld, err := layer.Digest()
+				if err != nil {
+					return nil, err
+				}
+				util.Assert("executor.convertlayer.relabel-digest", rd == ld, "relabel changed layer digest %s != %s", rd, ld)
+				return relabeled, nil
+			}
 			return tarball.LayerFromOpener(layer.Uncompressed, layerOpts...)
 		}
 		return nil, fmt.Errorf(

--- a/pkg/executor/fakes_test.go
+++ b/pkg/executor/fakes_test.go
@@ -19,6 +19,7 @@ package executor
 
 import (
 	"bytes"
+	"compress/gzip"
 	"errors"
 	"io"
 
@@ -188,7 +189,11 @@ func (f fakeLayer) DiffID() (v1.Hash, error) {
 }
 
 func (f fakeLayer) Compressed() (io.ReadCloser, error) {
-	return nil, nil
+	var buf bytes.Buffer
+	zw, _ := gzip.NewWriterLevel(&buf, gzip.BestSpeed)
+	zw.Write(f.TarContent)
+	zw.Close()
+	return io.NopCloser(&buf), nil
 }
 
 func (f fakeLayer) Uncompressed() (io.ReadCloser, error) {


### PR DESCRIPTION
Fixes #775

Cache layers are always stored as Docker v2, so reusing a cached layer in an OCI image means we must relabel its media type. Until now that relabel also always re-gzipped the layer, even though the compression was unchanged. This was wasteful but never popped up as problematic. However, with the recent upgrade to go-containerregistry we now have a `remote.pullLimiter` token when writing to an OCI-Layout, and the implementation is buggy and can leak those semaphores. When we save a stage with many identical layers and they all get re-compressed, we hit that leak and run into go-containerregistry's `internal/gzip` and deadlock.

With `FF_KANIKO_SKIP_RELABEL_RECOMPRESS` we now use the already-compressed blob instead of re-gzipping, side-stepping the leak entirely. Re-encoding still happens when the compression actually changes (gzip to zstd, or an uncompressed source), so the deadlock issue will not be avoided in all scenarios, but in most.