### PR TITLE
mz782: fix cache-lookahead precompute for FROM stages that set ENV

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz782
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz782
@@ -1,0 +1,10 @@
+# mz782: FF_KANIKO_CACHE_LOOKAHEAD triggers an assert in v1.27.6.
+# the precompute pass derives the dependent stage's cache key from the
+# base stage's input image instead of its output, so it misses the ENV the base stage sets.
+# The dependent RUN folds the env into its key, so the precomputed key disagrees with the built one and the
+# executor panics on the "executor.build.cache-lookahead" assertion.
+FROM busybox AS base
+ENV BLUBB=BLA
+
+FROM base
+RUN true

--- a/integration/images.go
+++ b/integration/images.go
@@ -99,6 +99,7 @@ var envsMap = map[string][]string{
 	"Dockerfile_test_issue_1039":                 {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_2066":                 {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_1837":                 {"FF_KANIKO_SQUASH_STAGES=0"},
+	"Dockerfile_test_issue_mz782":                {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_cg188":                {"SECRET=blubb"},
 	"Dockerfile_test_issue_mz793":                {"FF_KANIKO_VOLUME_SKIP_MKDIR=0"},
 	"Dockerfile_test_issue_mz473":                {"KANIKO_DIR=/kaniko2"},
@@ -487,6 +488,7 @@ func NewDockerFileBuilder() *DockerFileBuilder {
 		"Dockerfile_test_issue_mz637":   {},
 		"Dockerfile_test_issue_mz334":   {},
 		"Dockerfile_test_issue_mz655":   {},
+		"Dockerfile_test_issue_mz782":   {},
 		"Dockerfile_test_issue_mz793":   {},
 	}
 	d.TestOCICacheDockerfiles = map[string]struct{}{

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -279,7 +279,7 @@ func redirectCacheKey(inferredKey CompositeCache, layerCache cache.LayerCache) (
 	return NewCompositeCache(rawKey), nil
 }
 
-func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, args *dockerfile.BuildArgs, opts *config.KanikoOptions, fileContext util.FileContext, layerCache cache.LayerCache, stageFinalCacheKeys map[int]string, externalImageDigests map[string]string, hasContext bool) (string, *stageCacheInfo, error) {
+func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, args *dockerfile.BuildArgs, opts *config.KanikoOptions, fileContext util.FileContext, layerCache cache.LayerCache, stageFinalCacheKeys map[int]string, externalImageDigests map[string]string, hasContext bool) (string, *stageCacheInfo, v1.Config, error) {
 	keyValid := compositeKeyPtr != nil
 	if hasContext {
 		util.Assert("executor.optimize.keyValid", keyValid, "optimize: key must be valid")
@@ -307,7 +307,7 @@ func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, 
 	sawCacheMiss := false
 	finalCacheKey, err := compositeKey.Hash()
 	if err != nil {
-		return "", ci, err
+		return "", ci, v1.Config{}, err
 	}
 	cmdCountBeforeOptimize := len(s.cmds)
 	// Possibly replace commands with their cached implementations.
@@ -328,12 +328,12 @@ func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, 
 					if err == nil {
 						inferredCK, err := inferredKey.Hash()
 						if err != nil {
-							return "", ci, err
+							return "", ci, v1.Config{}, err
 						}
 						ci.redirectKeys[i] = inferredCK
 						contentKey, err := redirectCacheKey(inferredKey, layerCache)
 						if err != nil {
-							return "", ci, err
+							return "", ci, v1.Config{}, err
 						}
 						if contentKey != nil {
 							compositeKey = *contentKey
@@ -351,13 +351,13 @@ func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, 
 			} else {
 				files, err := command.FilesUsedFromContext(&cfg, args)
 				if err != nil {
-					return "", ci, fmt.Errorf("failed to get files used from context: %w", err)
+					return "", ci, v1.Config{}, fmt.Errorf("failed to get files used from context: %w", err)
 				}
 
 				prevCompositeKey := compositeKey.Clone()
 				compositeKey, err = populateCompositeKey(command, files, compositeKey, args, cfg.Env, fileContext, nil, nil)
 				if err != nil {
-					return "", ci, err
+					return "", ci, v1.Config{}, err
 				}
 
 				// mz334: assert the inferred key pointer resolves to the same content key.
@@ -366,21 +366,21 @@ func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, 
 					if err == nil {
 						inferredCK, err := inferredKey.Hash()
 						if err != nil {
-							return "", ci, err
+							return "", ci, v1.Config{}, err
 						}
 						ci.redirectKeys[i] = inferredCK
 						contentKey, err := redirectCacheKey(inferredKey, layerCache)
 						if err != nil {
-							return "", ci, err
+							return "", ci, v1.Config{}, err
 						}
 						if contentKey != nil {
 							ick, err := contentKey.Hash()
 							if err != nil {
-								return "", ci, err
+								return "", ci, v1.Config{}, err
 							}
 							ck, err := compositeKey.Hash()
 							if err != nil {
-								return "", ci, err
+								return "", ci, v1.Config{}, err
 							}
 							util.Assert("executor.compositekey.key-match", ick == ck, "pointer inferred content key %v does not match the computed content key %v", ick, ck)
 							// mz334: log when the inferred key produced the hit (integration test observability only).
@@ -394,7 +394,7 @@ func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, 
 			logrus.Debugf("Optimize: composite key for command %v %v", command.String(), compositeKey)
 			ck, err := compositeKey.Hash()
 			if err != nil {
-				return "", ci, fmt.Errorf("failed to hash composite key: %w", err)
+				return "", ci, v1.Config{}, fmt.Errorf("failed to hash composite key: %w", err)
 			}
 
 			logrus.Debugf("Optimize: cache key for command %v %v", command.String(), ck)
@@ -428,7 +428,7 @@ func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, 
 		// Mutate the config for any commands that require it.
 		if command.MetadataOnly() {
 			if err := command.ExecuteCommand(&cfg, args); err != nil {
-				return "", ci, err
+				return "", ci, v1.Config{}, err
 			}
 		}
 	}
@@ -441,7 +441,7 @@ func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, 
 	if hasContext || keyValid {
 		util.Assert("executor.optimize.finalcachekey", finalCacheKey != "", "optimize: finalCacheKey can't be empty")
 	}
-	return finalCacheKey, ci, nil
+	return finalCacheKey, ci, cfg, nil
 }
 
 func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOptions, fileContext util.FileContext, snapshotter snapShotter, crossStageDeps bool, stageFinalCacheKeys map[int]string, externalImageDigests map[string]string) error {
@@ -1036,6 +1036,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	cacheInfo := make([]*stageCacheInfo, lastStage.Index+1)
 	if opts.Cache && config.EnvBool("FF_KANIKO_CACHE_LOOKAHEAD") {
 		images := make([]v1.Image, lastStage.Index+1)
+		stageConfigs := make([]v1.Config, lastStage.Index+1)
 		for _, stage := range kanikoStages {
 			var baseImage v1.Image
 			if stage.BaseImageStoredLocally {
@@ -1069,7 +1070,11 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 				compositeKey = NewCompositeCache(sb.baseImageDigest)
 			}
 
-			finalCacheKey, ci, err := sb.optimize(compositeKey, sb.cf.Config, sb.args, opts, fileContext, NewLayerCache(opts), stageFinalCacheKeys, externalImageDigests, false)
+			cfg := sb.cf.Config
+			if stage.BaseImageStoredLocally {
+				cfg = stageConfigs[stage.BaseImageIndex]
+			}
+			finalCacheKey, ci, resultCfg, err := sb.optimize(compositeKey, cfg, sb.args, opts, fileContext, NewLayerCache(opts), stageFinalCacheKeys, externalImageDigests, false)
 			if err != nil {
 				return nil, fmt.Errorf("precompute: failed to optimize stage %d: %w", stage.Index, err)
 			}
@@ -1078,6 +1083,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 				stageFinalCacheKeys[stage.Index] = finalCacheKey
 			}
 			stageArgs[stage.Index] = sb.args
+			stageConfigs[stage.Index] = resultCfg
 			images[stage.Index] = baseImage
 		}
 	}
@@ -1179,7 +1185,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 
 		// Apply optimizations to the instructions.
 		precomputedKey := stageFinalCacheKeys[stage.Index]
-		finalCacheKey, buildCi, err := sb.optimize(compositeKey, sb.cf.Config, sb.args.Clone(), opts, fileContext, NewLayerCache(opts), stageFinalCacheKeys, externalImageDigests, true)
+		finalCacheKey, buildCi, _, err := sb.optimize(compositeKey, sb.cf.Config, sb.args.Clone(), opts, fileContext, NewLayerCache(opts), stageFinalCacheKeys, externalImageDigests, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to optimize instructions: %w", err)
 		}

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -607,7 +607,7 @@ func Test_stageBuilder_optimize(t *testing.T) {
 				cacheCommand: MockCachedDockerCommand{},
 			}
 			sb.cmds = []commands.DockerCommand{command}
-			_, _, err = sb.optimize(&ck, cf.Config, sb.args, tc.opts, util.FileContext{}, lc, nil, nil, true)
+			_, _, _, err = sb.optimize(&ck, cf.Config, sb.args, tc.opts, util.FileContext{}, lc, nil, nil, true)
 			if err != nil {
 				t.Errorf("Expected error to be nil but was %v", err)
 			}
@@ -1480,7 +1480,7 @@ RUN foobar
 				getFSFromImage = tc.mockGetFSFromImage
 			}
 			compositeKey := NewCompositeCache(sb.baseImageDigest)
-			_, _, err := sb.optimize(compositeKey, sb.cf.Config, sb.args, tc.opts, util.FileContext{}, lc, nil, nil, true)
+			_, _, _, err := sb.optimize(compositeKey, sb.cf.Config, sb.args, tc.opts, util.FileContext{}, lc, nil, nil, true)
 			if err != nil {
 				t.Errorf("failed to optimize instructions: %v", err)
 			}


### PR DESCRIPTION
Fixes #782

With `--cache` and `FF_KANIKO_CACHE_LOOKAHEAD`, building a stage that is `FROM` a previous local stage panics when the base stage sets an `ENV`. The lookahead precompute derives the dependent stage's cache key from the base stage's input image instead of its output, so it misses the `ENV` the base stage sets. The dependent `RUN` folds the env into its key, so the precomputed key disagrees with the build and the executor panics on the `executor.build.cache-lookahead` assertion.

`optimize` already applies the metadata commands to a throwaway config while computing keys but never returned it. It now returns the resulting config, and the precompute threads each stage's resulting config to its `FROM` dependents, so the dependent starts from the base stage's output config and the precomputed key matches the build. The build loop is unchanged, since it already reconstructs the base stage's output.

`Dockerfile_test_issue_mz782` reproduces the panic through `TestCache` and passes with the fix.