### PR TITLE
mz787: relax cache-lookahead hit assertion

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz787
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz787
@@ -1,0 +1,16 @@
+# mz787: the cache-lookahead precompute over-asserts hit predictions.
+# Panics since v1.27.6 with FF_KANIKO_CACHE_LOOKAHEAD enabled.
+# Stages a and b share an identical RUN, so they share a cache key. The
+# precompute looks up both before any build and sees two cold-cache misses.
+# The build pushes stage a's layer before stage b's lookup, so stage b hits
+# during the build. The keys match but the hit prediction does not, and the
+# executor panics on "executor.build.cache-lookahead.cache-hit" assertion.
+FROM busybox AS a
+RUN echo same > /same.txt
+
+FROM busybox AS b
+RUN echo same > /same.txt
+
+FROM busybox
+COPY --from=a /same.txt /a
+COPY --from=b /same.txt /b

--- a/integration/images.go
+++ b/integration/images.go
@@ -193,6 +193,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_target":                 {"--target=second"},
 	"Dockerfile_test_snapshotter_ignorelist": {"--use-new-run=true", "-v=trace"},
 	"Dockerfile_test_issue_mz334":            {"--cache-copy-layers=true"},
+	"Dockerfile_test_issue_mz787":            {"--cache=true"},
 	"Dockerfile_test_cache":                  {"--cache-copy-layers=true"},
 	"Dockerfile_test_cache_oci":              {"--cache-copy-layers=true"},
 	"Dockerfile_test_cache_install":          {"--cache-copy-layers=true"},

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -1167,11 +1167,9 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 			for i := range precompute.cacheKeys {
 				if precompute.cacheKeys[i] != "" {
 					util.Assert("executor.build.cache-lookahead.cache-key", precompute.cacheKeys[i] == buildCi.cacheKeys[i], "stage %d cmd %d: precompute cacheKey %q != build %q", stage.Index, i, precompute.cacheKeys[i], buildCi.cacheKeys[i])
-					util.Assert("executor.build.cache-lookahead.cache-hit", precompute.cacheHits[i] == buildCi.cacheHits[i], "stage %d cmd %d: precompute cacheHit %v != build %v (key %q)", stage.Index, i, precompute.cacheHits[i], buildCi.cacheHits[i], precompute.cacheKeys[i])
 				}
 				if precompute.redirectKeys[i] != "" {
 					util.Assert("executor.build.cache-lookahead.redirect-key", precompute.redirectKeys[i] == buildCi.redirectKeys[i], "stage %d cmd %d: precompute redirectKey %q != build %q", stage.Index, i, precompute.redirectKeys[i], buildCi.redirectKeys[i])
-					util.Assert("executor.build.cache-lookahead.redirect-hit", precompute.redirectHits[i] == buildCi.redirectHits[i], "stage %d cmd %d: precompute redirectHit %v != build %v (key %q)", stage.Index, i, precompute.redirectHits[i], buildCi.redirectHits[i], precompute.redirectKeys[i])
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #787.

The cache-lookahead precompute asserted that its predicted cache hits matched the build's. A hit reflects a cache lookup, and the cache is mutable between the two passes: an entry present at precompute time can be evicted, expire, or be removed by a concurrent build before the build runs, and the build can also self-populate a layer the precompute saw as a miss. So the two passes can legitimately disagree on a hit in either direction, and asserting it produces false panics. This drops the cache-hit and redirect-hit assertions entirely. The key assertions stay, since keys are derived deterministically from the Dockerfile and context, independent of cache state.

The seed-fallback divergence originally noted in #787 turned out to be a separate real panic, tracked and fixed in #789.
