### PR TITLE
mz793: VOLUME + --cache panics on without-fs assertion

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz793
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz793
@@ -1,0 +1,8 @@
+FROM busybox
+
+# mz793: VOLUME + --cache panics on assertion executor.build.without-fs since v1.27.4.
+# With FF_KANIKO_VOLUME_SKIP_MKDIR off, VOLUME creates the volume directory and it gets
+# snapshotted, but VolumeCommand reports MetadataOnly, so the without-fs assertion
+# (metadata-only commands snapshot zero files) fires. The assertion only holds once the
+# flag skips the mkdir, so it must be gated on the flag.
+VOLUME /data

--- a/integration/images.go
+++ b/integration/images.go
@@ -100,6 +100,7 @@ var envsMap = map[string][]string{
 	"Dockerfile_test_issue_2066":                 {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_1837":                 {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_cg188":                {"SECRET=blubb"},
+	"Dockerfile_test_issue_mz793":                {"FF_KANIKO_VOLUME_SKIP_MKDIR=0"},
 	"Dockerfile_test_issue_mz473":                {"KANIKO_DIR=/kaniko2"},
 	"Dockerfile_test_issue_mz511":                {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_mz529":                {"FF_KANIKO_SQUASH_STAGES=0"},
@@ -269,6 +270,10 @@ var diffArgsMap = map[string][]string{
 	// mz595: surprisingly the missing files are **not** picked up if we ignore layer-length-mismatch,
 	// which we do by default in TestRun, we should move to disable that globally urgently.
 	"TestRun/test_Dockerfile_test_issue_mz595": {"--extra-ignore-layer-length-mismatch=false"},
+	// mz793: with FF_KANIKO_VOLUME_SKIP_MKDIR off, VOLUME creates the directory fresh on
+	// each build, so its mtime differs between the two cached builds. That divergence is the
+	// known volume non-determinism the flag fixes, here we only assert the build no longer panics.
+	"TestCache/test_cache_Dockerfile_test_issue_mz793": {"--extra-ignore-files=data/"},
 }
 
 // output check to do when building with kaniko
@@ -481,6 +486,7 @@ func NewDockerFileBuilder() *DockerFileBuilder {
 		"Dockerfile_test_issue_mz637":   {},
 		"Dockerfile_test_issue_mz334":   {},
 		"Dockerfile_test_issue_mz655":   {},
+		"Dockerfile_test_issue_mz793":   {},
 	}
 	d.TestOCICacheDockerfiles = map[string]struct{}{
 		"Dockerfile_test_cache_oci":         {},

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -625,8 +625,10 @@ func takeSnapshot(files []string, shdDelete bool, opts *config.KanikoOptions, sn
 	if files == nil || opts.SingleSnapshot {
 		snapshot, snapshotted, err = snapshotter.TakeSnapshotFS()
 	} else {
-		// Volumes are very weird. They get snapshotted in the next command.
-		files = append(files, util.Volumes()...)
+		if !config.EnvBool("FF_KANIKO_VOLUME_SKIP_MKDIR") {
+			// Volumes are very weird. They get snapshotted in the next command.
+			files = append(files, util.Volumes()...)
+		}
 		snapshot, snapshotted, err = snapshotter.TakeSnapshot(files, shdDelete)
 	}
 	timing.DefaultRun.Stop(t)

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -565,7 +565,9 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 				// So the only case where we don't need a filesystem is if all commands are MetadataOnly.
 				util.Assert("executor.build.metadata-only", command.MetadataOnly(), "build: non-MetadataOnly command %q ran without unpacked filesystem in stage %d", command.String(), s.index)
 			}
-			if command.MetadataOnly() && !opts.SingleSnapshot {
+			_, isVolume := command.(*commands.VolumeCommand)
+			volumeCreatesFiles := isVolume && !config.EnvBool("FF_KANIKO_VOLUME_SKIP_MKDIR")
+			if command.MetadataOnly() && !opts.SingleSnapshot && !volumeCreatesFiles {
 				// MetadataOnly commands must not change or even need the filesystem.
 				util.Assert("executor.build.without-fs", snapshotted == 0, "build: MetadataOnly command %q snapshotted %d file(s)", command.String(), snapshotted)
 			}


### PR DESCRIPTION
Fixes #793

`VOLUME` creates its directory and, with `--cache` on, that directory gets snapshotted. `VolumeCommand` reports `MetadataOnly` though, so the `executor.build.without-fs` assertion added in v1.27.4 sees a metadata-only command that touched the filesystem and panics. `FF_KANIKO_VOLUME_SKIP_MKDIR` already addresses the underlying volume weirdness by skipping the mkdir, so the zero-files invariant only holds once that flag is active. This exempts `VOLUME` from the assertion while the flag is off, and keeps asserting it for every other command and for `VOLUME` once the flag is on.