### PR TITLE
mz774: cross-stage COPY emits spurious whiteouts on cache hit

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `FF_KANIKO_OCI_SCRATCH_BASE`](#flag-ff_kaniko_oci_scratch_base)
       - [Flag `FF_KANIKO_VOLUME_SKIP_MKDIR`](#flag-ff_kaniko_volume_skip_mkdir)
       - [Flag `FF_KANIKO_PRESERVE_HARDLINKS`](#flag-ff_kaniko_preserve_hardlinks)
+      - [Flag `FF_KANIKO_SKIP_WRITE_WHITEOUTS`](#flag-ff_kaniko_skip_write_whiteouts)
       - [Flag `FF_KANIKO_BUILDKIT_ARG_ENV_PRECEDENCE`](#flag-ff_kaniko_buildkit_arg_env_precedence)
       - [Flag `FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY`](#flag-ff_kaniko_infer_cross_stage_cache_key)
       - [Flag `FF_KANIKO_CACHE_LOOKAHEAD`](#flag-ff_kaniko_cache_lookahead)
@@ -1221,6 +1222,12 @@ Becomes default in `v1.28.0`.
 When copying a directory via `COPY --from=<stage>`, kaniko copies each file independently, breaking hardlink relationships. Files that shared a single inode in the source stage become independent copies in the output image, which can significantly inflate image size for images that rely heavily on hardlinks (e.g. `git` installations where many binaries are hardlinked together).
 Set this flag to `true` to preserve hardlinks during `COPY --from`. Defaults to `false`.
 Becomes default in `v1.28.0`.
+
+#### Flag `FF_KANIKO_SKIP_WRITE_WHITEOUTS`
+
+When kaniko extracts a cached layer it applies the layer's whiteouts by deleting the target files, but it also writes the `.wh.<name>` marker files onto the working filesystem. With `--cache-copy-layers` a later cross-stage `COPY --from=<stage>` copies such a marker verbatim and commits it as a real whiteout, so a cache-hit build deletes a file that the cache-miss build kept.
+Set this flag to `true` to skip writing the marker files, the deletion alone already applies the whiteout. Defaults to `false`.
+Becomes default in `v1.29.0`.
 
 #### Flag `FF_KANIKO_BUILDKIT_ARG_ENV_PRECEDENCE`
 

--- a/integration/dockerfiles/Dockerfile_test_issue_mz774
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz774
@@ -1,0 +1,17 @@
+# mz774: on v1.27.6 with --cache-copy-layers a cache-hit build drops /opt/keep,
+# while the cache-miss build that populated the cache keeps it.
+#
+# base creates /opt/keep in a RUN layer that nothing later in the stage reads.
+# mutate removes it. On a cache hit the cached rm layer is extracted with its
+# whiteout marker written to mutate's filesystem as a literal /opt/.wh.keep file.
+# final's COPY --from=mutate /opt/ then copies that marker verbatim and commits
+# it as a real whiteout, deleting /opt/keep. The cache-miss path does a real rm
+# so no marker exists and the COPY stays additive, hence the two builds diverge.
+FROM busybox AS base
+RUN mkdir -p /opt/keep && echo hi > /opt/keep/marker
+
+FROM base AS mutate
+RUN rm -rf /opt/keep
+
+FROM base AS final
+COPY --from=mutate /opt/ /opt/

--- a/integration/images.go
+++ b/integration/images.go
@@ -101,6 +101,7 @@ var envsMap = map[string][]string{
 	"Dockerfile_test_issue_1837":                 {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_mz782":                {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_cg188":                {"SECRET=blubb"},
+	"Dockerfile_test_issue_mz774":                {"FF_KANIKO_SKIP_WRITE_WHITEOUTS=1"},
 	"Dockerfile_test_issue_mz793":                {"FF_KANIKO_VOLUME_SKIP_MKDIR=0"},
 	"Dockerfile_test_issue_mz473":                {"KANIKO_DIR=/kaniko2"},
 	"Dockerfile_test_issue_mz511":                {"FF_KANIKO_SQUASH_STAGES=0"},
@@ -204,6 +205,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_cache_copy_oci":         {"--cache-copy-layers=true"},
 	"Dockerfile_test_issue_add":              {"--cache-copy-layers=true"},
 	"Dockerfile_test_issue_mz655":            {"--cache-copy-layers=true"},
+	"Dockerfile_test_issue_mz774":            {"--cache-copy-layers=true"},
 	"Dockerfile_test_volume_3":               {"--skip-unused-stages=false"},
 	"Dockerfile_test_multistage":             {"--skip-unused-stages=false"},
 	"Dockerfile_test_copy_root_multistage":   {"--skip-unused-stages=false"},
@@ -488,6 +490,7 @@ func NewDockerFileBuilder() *DockerFileBuilder {
 		"Dockerfile_test_issue_mz637":   {},
 		"Dockerfile_test_issue_mz334":   {},
 		"Dockerfile_test_issue_mz655":   {},
+		"Dockerfile_test_issue_mz774":   {},
 		"Dockerfile_test_issue_mz782":   {},
 		"Dockerfile_test_issue_mz793":   {},
 	}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -225,7 +225,8 @@ func extractLayer(i int, l v1.Layer, root string, cfg *FSConfig) ([]string, erro
 				return nil, fmt.Errorf("removing whiteout %s: %w", hdr.Name, err)
 			}
 
-			if !cfg.includeWhiteout {
+			// mz774: whiteout deletion is already applied, the marker is not needed in the filesystem
+			if !cfg.includeWhiteout || config.EnvBool("FF_KANIKO_SKIP_WRITE_WHITEOUTS") {
 				logrus.Trace("Not including whiteout files")
 				continue
 			}


### PR DESCRIPTION
Fixes #774

On a cache hit the caching commands extract the cached layer with its whiteout markers written onto the working filesystem, not merely applied. With `--cache-copy-layers` a later cross-stage `COPY --from=<stage>` then copies such a `.wh.<name>` marker verbatim and commits it as a real whiteout, so the cache-hit build deletes a file that the cache-miss build kept. The deletion is already applied during extraction, so the marker on disk serves no purpose and only leaks into the COPY. `FF_KANIKO_SKIP_WRITE_WHITEOUTS` skips writing it and becomes the default in `v1.29.0`. A follow-up on this ticket will make kaniko match docker for literal `.wh.`-prefixed files created during a build.