### PR TITLE
use KanikoEnv in all integration executor invocations

### DIFF
--- a/integration/images.go
+++ b/integration/images.go
@@ -64,6 +64,15 @@ func addCoverageFlags(flags []string) []string {
 	return append(flags, "-v", coverageDir+":/covdata", "-e", "GOCOVERDIR=/covdata")
 }
 
+// addKanikoEnvFlags passes the suite's feature-flag matrix (KanikoEnv) to the executor
+// container. Every executor invocation must use it so all tests exercise the same flags.
+func addKanikoEnvFlags(flags []string) []string {
+	for _, envVariable := range KanikoEnv {
+		flags = append(flags, "-e", envVariable)
+	}
+	return flags
+}
+
 // Arguments to build Dockerfiles with, used for both docker and kaniko builds
 var argsMap = map[string][]string{
 	"Dockerfile_test_run":        {"file=/file"},

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -330,6 +330,7 @@ func testGitBuildcontextHelper(t *testing.T, url string, commit string, branch s
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -401,6 +402,7 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
 	dockerRunFlags = append(
 		dockerRunFlags,
 		ExecutorImage,
@@ -445,6 +447,7 @@ func TestBuildViaRegistryMirrors(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -487,6 +490,7 @@ func TestBuildViaRegistryMap(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -514,6 +518,7 @@ func TestBuildSkipFallback(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -555,6 +560,7 @@ func TestKanikoDir(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -599,6 +605,7 @@ func TestBuildWithLabels(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -640,6 +647,7 @@ func TestBuildWithHTTPError(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -1140,6 +1148,7 @@ func TestExitCodePropagation(t *testing.T) {
 		}
 		dockerFlags = addServiceAccountFlags(dockerFlags, "")
 		dockerFlags = addCoverageFlags(dockerFlags)
+		dockerFlags = addKanikoEnvFlags(dockerFlags)
 		dockerFlags = append(dockerFlags, ExecutorImage,
 			"-c", "dir:///workspace/",
 			"-f", "./Dockerfile_exit_code_propagation",
@@ -1193,6 +1202,7 @@ func TestBuildWithAnnotations(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -1230,6 +1240,12 @@ func TestPushFromArtifact(t *testing.T) {
 			runExecutor := func(executorArgs ...string) {
 				t.Helper()
 				flags := []string{"run", "--rm", "--net=host", "-v", outFlag + ":/out"}
+				flags = addKanikoEnvFlags(flags)
+				// mz731 keeps OCI base layers verbatim on the direct push, but the
+				// docker-archive --tar-path writer rewrites them to docker mediatypes, so
+				// the push-from-artifact image would not match. Disable it (after the
+				// KanikoEnv default) so both paths re-tar the base identically.
+				flags = append(flags, "-e", "FF_KANIKO_REPRODUCIBLE_PRESERVE_BASE_LAYERS=0")
 				flags = addServiceAccountFlags(flags, config.serviceAccount)
 				flags = addCoverageFlags(flags)
 				flags = append(flags, ExecutorImage)


### PR DESCRIPTION
Several integration tests build the executor docker command by hand and never applied KanikoEnv, so they ran the executor on defaults instead of the suite's feature-flag matrix. That gap is what let the REPRODUCIBLE_PRESERVE_BASE_LAYERS divergence stay hidden until the v1.28.0 graduation flipped its default, because the one test that compares a tar artifact against a direct push (TestPushFromArtifact) never saw the flag on.

Route every executor invocation through a shared addKanikoEnvFlags helper so all tests exercise the same flags. TestPushFromArtifact keeps FF_KANIKO_REPRODUCIBLE_PRESERVE_BASE_LAYERS disabled, layered after KanikoEnv, because the docker-archive --tar-path writer cannot preserve OCI base layers and the push-from-artifact image would otherwise not match the direct push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration test consistency when comparing Docker- and Kaniko-built images.
  * Ensured Kaniko environment settings are consistently applied across image-building scenarios.
  * Updated artifact-based push comparisons to preserve matching image layers and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->