### PR TITLE
bump docker to 29.5.2 and k3s to v1.36.2 in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 # v5.2.0
         with:
-          version: 29.2.1
+          version: 29.6.0
 
       - run: make install-diffoci k3s-setup
       - run: make ${{ matrix.make-target }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 # v5.2.0
         with:
-          version: 29.6.0
+          version: 29.5.2
 
       - run: make install-diffoci k3s-setup
       - run: make ${{ matrix.make-target }}

--- a/scripts/k3s-setup.sh
+++ b/scripts/k3s-setup.sh
@@ -20,7 +20,7 @@ export INSTALL_K3S_EXEC="--write-kubeconfig-mode=0644"
 mkdir -p "${HOME}/.kube"
 export K3S_KUBECONFIG_OUTPUT="${HOME}/.kube/config"
 export KUBECONFIG="${HOME}/.kube/config"
-INSTALL_K3S_VERSION="v1.35.4+k3s1" curl -sfL https://get.k3s.io | sh -
+INSTALL_K3S_VERSION="v1.36.2+k3s1" curl -sfL https://get.k3s.io | sh -
 export SCRIPT_PATH="$(realpath $(dirname $0))"
 timeout 5m bash -c 'until kubectl cluster-info 2>/dev/null | grep "CoreDNS" >/dev/null; do sleep 1; done'
 


### PR DESCRIPTION
Bumps the Docker Engine version (29.2.1 -> 29.5.2) and the k3s version (v1.35.4+k3s1 -> v1.36.2+k3s1) used by the integration test workflow. 29.6.0 exists on download.docker.com but is not yet in setup-docker-action@v5.2.0's bundled release list, so it cannot be installed yet.