### PR TITLE
cg326: use securejoin for path resolution in tar extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `FF_KANIKO_SCOPED_DOCKERIGNORE`](#flag-ff_kaniko_scoped_dockerignore)
       - [Flag `FF_KANIKO_COPY_CACHEKEY_FOLD_ARGS`](#flag-ff_kaniko_copy_cachekey_fold_args)
       - [Flag `FF_KANIKO_SKIP_RELABEL_RECOMPRESS`](#flag-ff_kaniko_skip_relabel_recompress)
+      - [Flag `FF_KANIKO_SECUREJOIN_EXTRACTION`](#flag-ff_kaniko_securejoin_extraction)
     - [Assertion Overrides](#assertion-overrides)
     - [Debug Image](#debug-image)
   - [Security](#security)
@@ -1315,6 +1316,13 @@ When a cached layer is reused in an image of a different media-type vendor, kani
 Set this flag to `true` to skip the unecessary re-compression and serve the relabeled already-compressed blob.
 Defaults to `false`.
 Becomes default in `v1.29.0`.
+
+#### Flag `FF_KANIKO_SECUREJOIN_EXTRACTION`
+
+When unpacking image layers kaniko joins each tar entry path lexically, so a malicious base image can ship an escaping symlink followed by a write through it and land the write outside the extraction root, for example overwriting `/kaniko/tini` to gain RCE.
+Set this flag to `true` to resolve each entry's parent with SecureJoin so the write stays contained inside the destination.
+Defaults to `true`.
+Will be deprecated in `v1.29.0`.
 
 ### Assertion Overrides
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.12.0
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589
 	github.com/containerd/platforms v1.0.0-rc.4
+	github.com/cyphar/filepath-securejoin v0.6.1
 	github.com/docker/cli v29.6.0+incompatible
 	github.com/docker/docker-credential-helpers v0.9.8
 	github.com/ePirat/docker-credential-gitlabci v1.0.0
@@ -89,7 +90,6 @@ require (
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/typeurl/v2 v2.3.0 // indirect
-	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect

--- a/integration/dockerfiles/Dockerfile_test_issue_cg326_2
+++ b/integration/dockerfiles/Dockerfile_test_issue_cg326_2
@@ -1,0 +1,15 @@
+FROM busybox
+
+# Attack 2: symlink path traversal.
+# A malicious upstream image can escape the dependency dir via a symlink even
+# though the explicit "../" form (Attack 1) is now rejected.
+# Before build, we prefetch, untar and store images in /kaniko/deps/<imagename>.
+# The image layer contains a symlink "evil" -> "../../.." followed by a regular
+# file "evil/tini". kaniko stores the symlink verbatim, then writes the file
+# through it: os.Create("/kaniko/deps/<imagename>/evil/tini") follows "evil"
+# and lands on "/kaniko/tini", overwriting kaniko's own tini binary.
+# The "../" check on entry names does not catch this because "evil/tini" has no "..".
+# Multiple levels of ".." are needed because image names are not slugified.
+COPY --from=localhost:5000/symlink-traversal-malicious:latest marker marker
+
+RUN ls -la /kaniko || true

--- a/integration/dockerfiles/Dockerfile_test_issue_cg326_3
+++ b/integration/dockerfiles/Dockerfile_test_issue_cg326_3
@@ -1,0 +1,13 @@
+FROM busybox
+
+# Regression flagged against the cg326 symlink-target check.
+# Some base images ship a symlink with more ".." than its depth. Real example,
+# sonarsource/sonar-scanner-cli@sha256:23ca0f137965d9dff2198074043fd48d386280bc5d0ccac8c8349cea4cf096a9:
+#   usr/lib/jvm/java-21-amazon-corretto.x86_64/lib/security/cacerts
+#     -> ../../../../../../../../../../etc/pki/java/cacerts
+# The extra ".." are a sled, the OS clamps them at the root so it resolves to
+# /etc/pki/java/cacerts. The lexical check wrongly rejected it (filepath.Clean
+# leaves a leading "../"). Crafted synthetically to avoid pulling 200MB in CI.
+COPY --from=localhost:5000/excess-dotdot-symlink:latest marker marker
+
+RUN ls -la / || true

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -197,6 +197,18 @@ func buildRequiredImages() error {
 		return err
 	}
 
+	symlinkMaliciousRef := strings.ToLower(config.imageRepo + "symlink-traversal-malicious:latest")
+	err = pushMaliciousSymlinkTraversalImage(symlinkMaliciousRef)
+	if err != nil {
+		return err
+	}
+
+	excessDotdotRef := strings.ToLower(config.imageRepo + "excess-dotdot-symlink:latest")
+	err = pushExcessDotdotSymlinkImage(excessDotdotRef)
+	if err != nil {
+		return err
+	}
+
 	err = mutateMalformedOCIImageConfig(config.malformedOCIImage)
 	if err != nil {
 		return err
@@ -738,6 +750,109 @@ func pushMaliciousPathTraversalImage(imageRef string) error {
 	}
 	if err := remote.Write(ref, img, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
 		return fmt.Errorf("pushing malicious image to %s: %v", imageRef, err)
+	}
+	return nil
+}
+
+// pushMaliciousSymlinkTraversalImage creates and pushes a minimal OCI image whose
+// single layer escapes the extraction dir through a symlink. The layer holds a
+// symlink "evil" -> "/kaniko" followed by a regular file "evil/tini". Docker
+// cannot produce such a layer, so the image is crafted programmatically.
+func pushMaliciousSymlinkTraversalImage(imageRef string) error {
+	layer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     "marker",
+			Typeflag: tar.TypeReg,
+			Size:     0,
+			Mode:     0o644,
+		}); err != nil {
+			return nil, err
+		}
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     "evil",
+			Typeflag: tar.TypeSymlink,
+			Linkname: "../../..",
+			Mode:     0o777,
+		}); err != nil {
+			return nil, err
+		}
+		payload := "#!/bin/sh\necho WARN HIJACKED"
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     "evil/tini",
+			Typeflag: tar.TypeReg,
+			Size:     int64(len(payload)),
+			Mode:     0o755,
+		}); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write([]byte(payload)); err != nil {
+			return nil, err
+		}
+		tw.Close()
+		return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
+	})
+	if err != nil {
+		return fmt.Errorf("creating symlink-traversal layer: %v", err)
+	}
+
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	if err != nil {
+		return fmt.Errorf("appending layer to empty image: %v", err)
+	}
+
+	ref, err := name.ParseReference(imageRef, name.WeakValidation)
+	if err != nil {
+		return fmt.Errorf("parsing image ref %s: %v", imageRef, err)
+	}
+	if err := remote.Write(ref, img, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
+		return fmt.Errorf("pushing malicious image to %s: %v", imageRef, err)
+	}
+	return nil
+}
+
+// pushExcessDotdotSymlinkImage pushes a minimal image whose layer holds a
+// symlink with more ".." than its depth, mirroring the Corretto-via-RPM cacerts
+// link (e.g. sonarsource/sonar-scanner-cli). The OS clamps it at the root.
+func pushExcessDotdotSymlinkImage(imageRef string) error {
+	layer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     "marker",
+			Typeflag: tar.TypeReg,
+			Size:     0,
+			Mode:     0o644,
+		}); err != nil {
+			return nil, err
+		}
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     "usr/lib/jvm/java-21-amazon-corretto.x86_64/lib/security/cacerts",
+			Typeflag: tar.TypeSymlink,
+			Linkname: "../../../../../../../../../../etc/pki/java/cacerts",
+			Mode:     0o777,
+		}); err != nil {
+			return nil, err
+		}
+		tw.Close()
+		return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
+	})
+	if err != nil {
+		return fmt.Errorf("creating excess-dotdot-symlink layer: %v", err)
+	}
+
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	if err != nil {
+		return fmt.Errorf("appending layer to empty image: %v", err)
+	}
+
+	ref, err := name.ParseReference(imageRef, name.WeakValidation)
+	if err != nil {
+		return fmt.Errorf("parsing image ref %s: %v", imageRef, err)
+	}
+	if err := remote.Write(ref, img, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
+		return fmt.Errorf("pushing excess-dotdot-symlink image to %s: %v", imageRef, err)
 	}
 	return nil
 }

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -32,6 +32,7 @@ import (
 	"syscall"
 	"time"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/moby/go-archive"
 	"github.com/moby/patternmatcher"
@@ -86,6 +87,8 @@ var defaultIgnoreList = []IgnoreListEntry{
 var ignorelist = append([]IgnoreListEntry{}, defaultIgnoreList...)
 
 var volumes = []string{}
+
+var secureExtraction = config.EnvBoolDefault("FF_KANIKO_SECUREJOIN_EXTRACTION", true)
 
 type FileContext struct {
 	Root          string
@@ -204,13 +207,20 @@ func extractLayer(i int, l v1.Layer, root string, cfg *FSConfig) ([]string, erro
 		}
 		path := filepath.Join(root, cleanedName)
 		base := filepath.Base(path)
-		dir := filepath.Dir(path)
 
 		if strings.HasPrefix(base, archive.WhiteoutPrefix) {
-			logrus.Tracef("Whiting out %s", path)
+			dir := filepath.Dir(path)
+			if secureExtraction {
+				securePath, err := securejoin.SecureJoin(root, cleanedName)
+				if err != nil {
+					return nil, fmt.Errorf("resolving whiteout path for %q: %w", hdr.Name, err)
+				}
+				dir = filepath.Dir(securePath)
+			}
 
 			name := strings.TrimPrefix(base, archive.WhiteoutPrefix)
 			path := filepath.Join(dir, name)
+			logrus.Tracef("Whiting out %s", path)
 
 			if CheckCleanedPathAgainstIgnoreList(path) {
 				logrus.Tracef("Not deleting %s, as it's ignored", path)
@@ -350,7 +360,24 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 		return fmt.Errorf("tar entry %q is not allowed: references parent directory", hdr.Name)
 	}
 
-	path := filepath.Join(dest, cleanedName)
+	var path string
+	if secureExtraction {
+		// cg330: SecureJoin the parent only, then append the basename lexically. Joining
+		// the full name would resolve the final component when it is a symlink we
+		// mean to overwrite, writing through it and creating loops like
+		// bin/sh -> dash -> dash.
+		secureDir, err := securejoin.SecureJoin(dest, filepath.Dir(cleanedName))
+		if err != nil {
+			if !errors.Is(err, syscall.ELOOP) {
+				return fmt.Errorf("resolving path for %q: %w", hdr.Name, err)
+			}
+			logrus.Warnf("Skipping %q: parent path cannot be securely resolved (symlink loop)", hdr.Name)
+			return nil
+		}
+		path = filepath.Join(secureDir, filepath.Base(cleanedName))
+	} else {
+		path = filepath.Join(dest, cleanedName)
+	}
 	base := filepath.Base(path)
 	dir := filepath.Dir(path)
 	mode := hdr.FileInfo().Mode()
@@ -373,7 +400,7 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 		// It's possible a file is in the tar before its directory,
 		// or a file was copied over a directory prior to now
 		fi, err := os.Stat(dir)
-		if os.IsNotExist(err) || !fi.IsDir() {
+		if err != nil || !fi.IsDir() {
 			logrus.Debugf("Base %s for file %s does not exist. Creating.", base, path)
 
 			if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -420,6 +447,14 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 		}
 	case tar.TypeDir:
 		logrus.Tracef("Creating dir %s", path)
+		if secureExtraction {
+			fi, lerr := os.Lstat(path)
+			if lerr == nil && fi.Mode()&os.ModeSymlink != 0 {
+				if err := os.Remove(path); err != nil {
+					return fmt.Errorf("error removing symlink %s to make way for new directory: %w", path, err)
+				}
+			}
+		}
 		if err := MkdirAllWithPermissions(path, mode, int64(uid), int64(gid)); err != nil {
 			return err
 		}
@@ -458,7 +493,16 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 		if cleanedLink == ".." || strings.HasPrefix(cleanedLink, "../") {
 			return fmt.Errorf("hardlink target %q is not allowed: references parent directory", hdr.Linkname)
 		}
-		link := filepath.Clean(filepath.Join(dest, hdr.Linkname))
+		var link string
+		if secureExtraction {
+			resolved, err := securejoin.SecureJoin(dest, hdr.Linkname)
+			if err != nil {
+				return fmt.Errorf("invalid hardlink target %q: %w", hdr.Linkname, err)
+			}
+			link = resolved
+		} else {
+			link = filepath.Clean(filepath.Join(dest, hdr.Linkname))
+		}
 		if err := os.Link(link, path); err != nil {
 			return err
 		}

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -882,6 +882,168 @@ func TestExtractFile_PathTraversal(t *testing.T) {
 		}
 	})
 
+	t.Run("symlink with relative escaping target is created but write-through is confined", func(t *testing.T) {
+		// A symlink whose target lexically escapes dest must still be created
+		// verbatim (this is how real base images ship, e.g. amazoncorretto's
+		// cacerts -> ../../../../../../../../../../etc/pki/java/cacerts). The
+		// traversal protection is enforced when a later entry writes *through*
+		// the symlink, not by rejecting the link target.
+		dest := t.TempDir()
+		hdr := linkHeader("./link", "../outside")
+		if err := ExtractFile(dest, hdr, filepath.Clean(hdr.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatalf("symlink with relative escaping target should be created, not rejected: %v", err)
+		}
+		target, err := os.Readlink(filepath.Join(dest, "link"))
+		if err != nil {
+			t.Fatalf("symlink was not created: %v", err)
+		}
+		if target != "../outside" {
+			t.Fatalf("symlink target = %q, want %q (stored verbatim)", target, "../outside")
+		}
+
+		// Writing through the symlink must stay inside dest. SecureJoin on the
+		// parent resolves "link" and clamps it within dest, so the file lands at
+		// dest/outside/written.txt, never at the sibling ../outside.
+		writeHdr := fileHeader("./link/written.txt", "data", 0o644, defaultTestTime)
+		if err := ExtractFile(dest, writeHdr, filepath.Clean(writeHdr.Name), bytes.NewReader([]byte("data"))); err != nil {
+			t.Fatalf("write through symlink should succeed (confined), got: %v", err)
+		}
+		if _, statErr := os.Stat(filepath.Join(filepath.Dir(dest), "outside", "written.txt")); statErr == nil {
+			t.Fatal("file was written outside dest through symlink")
+		}
+		if _, statErr := os.Stat(filepath.Join(dest, "outside", "written.txt")); statErr != nil {
+			t.Fatalf("write was not confined to dest/outside as expected: %v", statErr)
+		}
+	})
+
+	t.Run("regular file overwriting a pre-existing escaping symlink is contained", func(t *testing.T) {
+		// A tar can ship an (absolute or relative) escaping symlink and then a
+		// regular file at the SAME name. The write must NOT follow the symlink
+		// to its target: FilepathExists uses Lstat and the entry is removed
+		// before os.Create, so a fresh regular file is written inside dest.
+		outsideDir := t.TempDir() // sibling of dest, must stay untouched
+		escaped := filepath.Join(outsideDir, "pwned")
+		dest := t.TempDir()
+
+		// 1) create the escaping symlink: ./evil -> <outsideDir>/pwned
+		linkHdr := linkHeader("./evil", escaped)
+		if err := ExtractFile(dest, linkHdr, filepath.Clean(linkHdr.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatalf("symlink creation should succeed: %v", err)
+		}
+		// 2) write a regular file at the same name with attacker content
+		fileHdr := fileHeader("./evil", "attacker", 0o644, defaultTestTime)
+		if err := ExtractFile(dest, fileHdr, filepath.Clean(fileHdr.Name), bytes.NewReader([]byte("attacker"))); err != nil {
+			t.Fatalf("overwriting symlink with file should succeed: %v", err)
+		}
+		// dest/evil must now be a regular file (the symlink was Lstat-removed
+		// before os.Create), not a symlink, and must hold the written content.
+		fi, err := os.Lstat(filepath.Join(dest, "evil"))
+		if err != nil {
+			t.Fatalf("lstat dest/evil: %v", err)
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			t.Fatal("dest/evil is still a symlink; should be a regular file")
+		}
+		got, err := os.ReadFile(filepath.Join(dest, "evil"))
+		if err != nil {
+			t.Fatalf("reading dest/evil: %v", err)
+		}
+		if string(got) != "attacker" {
+			t.Fatalf("dest/evil content = %q, want %q (write not confined in-dest)", got, "attacker")
+		}
+		// And nothing was created at the symlink target outside dest.
+		if _, statErr := os.Stat(escaped); statErr == nil {
+			t.Fatalf("write followed the symlink and escaped to %s", escaped)
+		}
+	})
+
+	t.Run("TypeDir must not chmod a directory outside dest via a pre-existing symlink", func(t *testing.T) {
+		// PSEC-1492 High: an escaping symlink (now stored verbatim) followed by
+		// a same-name directory entry must not let MkdirAllWithPermissions
+		// follow the symlink and chmod/chown the external target. The symlink is
+		// removed before the directory is created. Fails before the TypeDir fix.
+		outsideDir := t.TempDir()
+		victim := filepath.Join(outsideDir, "victim")
+		if err := os.Mkdir(victim, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		dest := t.TempDir()
+
+		// 1) escaping symlink ./evil -> <outsideDir>/victim
+		linkHdr := linkHeader("./evil", victim)
+		if err := ExtractFile(dest, linkHdr, filepath.Clean(linkHdr.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatalf("symlink creation should succeed: %v", err)
+		}
+		// 2) same-name directory entry with an attacker-controlled mode
+		dHdr := dirHeader("./evil", 0o777)
+		if err := ExtractFile(dest, dHdr, filepath.Clean(dHdr.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatalf("dir creation should succeed: %v", err)
+		}
+
+		// The external victim's mode must be unchanged (not chmod'd to 0777).
+		vi, err := os.Lstat(victim)
+		if err != nil {
+			t.Fatalf("lstat victim: %v", err)
+		}
+		if vi.Mode().Perm() != 0o700 {
+			t.Fatalf("external dir mode changed to %o; chmod escaped through the symlink", vi.Mode().Perm())
+		}
+		// dest/evil must now be a real directory, not the symlink.
+		di, err := os.Lstat(filepath.Join(dest, "evil"))
+		if err != nil {
+			t.Fatalf("lstat dest/evil: %v", err)
+		}
+		if di.Mode()&os.ModeSymlink != 0 {
+			t.Fatal("dest/evil is still a symlink; should be a real directory")
+		}
+		if !di.IsDir() {
+			t.Fatal("dest/evil is not a directory")
+		}
+	})
+
+	t.Run("entry whose parent is a symlink loop is skipped", func(t *testing.T) {
+		// SecureJoin returns ELOOP for a parent path containing a symlink loop.
+		// The entry must be skipped (returns nil, writes nothing) rather than
+		// written through an unresolved lexical path (PSEC-1492 ELOOP fallback).
+		dest := t.TempDir()
+		// Build a loop inside dest: a -> b, b -> a.
+		if err := ExtractFile(dest, linkHeader("./a", "b"), "a", bytes.NewReader(nil)); err != nil {
+			t.Fatalf("creating symlink a: %v", err)
+		}
+		if err := ExtractFile(dest, linkHeader("./b", "a"), "b", bytes.NewReader(nil)); err != nil {
+			t.Fatalf("creating symlink b: %v", err)
+		}
+		// An entry under the looping path must be skipped without error.
+		hdr := fileHeader("./a/foo.txt", "data", 0o644, defaultTestTime)
+		if err := ExtractFile(dest, hdr, filepath.Clean(hdr.Name), bytes.NewReader([]byte("data"))); err != nil {
+			t.Fatalf("entry under symlink loop should be skipped (nil), got: %v", err)
+		}
+		// Nothing should have been written under the looping parent.
+		if _, err := os.Lstat(filepath.Join(dest, "a", "foo.txt")); err == nil {
+			t.Fatal("file was written under a symlink-loop parent")
+		}
+	})
+
+	t.Run("symlink with excess-dotdot target (amazoncorretto cacerts) is allowed", func(t *testing.T) {
+		// Regression test for the #326/#330 symlink target check: a symlink
+		// deep in the tree whose target has more ".." than its depth resolves
+		// to the root at follow time and must not be rejected.
+		dest := t.TempDir()
+		name := "usr/lib/jvm/java-21-amazon-corretto/lib/security/cacerts"
+		target := "../../../../../../../../../../etc/pki/java/cacerts"
+		hdr := linkHeader(name, target)
+		if err := ExtractFile(dest, hdr, filepath.Clean(hdr.Name), bytes.NewReader(nil)); err != nil {
+			t.Fatalf("excess-dotdot symlink should be allowed: %v", err)
+		}
+		got, err := os.Readlink(filepath.Join(dest, name))
+		if err != nil {
+			t.Fatalf("symlink was not created: %v", err)
+		}
+		if got != target {
+			t.Fatalf("symlink target = %q, want %q (stored verbatim)", got, target)
+		}
+	})
+
 	t.Run("legitimate file succeeds", func(t *testing.T) {
 		dest := t.TempDir()
 		hdr := fileHeader("./subdir/file.txt", "content", 0o644, defaultTestTime)
@@ -948,6 +1110,87 @@ func TestUnTar_PathTraversal(t *testing.T) {
 		dest := t.TempDir()
 		if _, err := UnTar(buf, dest); err == nil {
 			t.Fatal("expected error for hardlink with dotdot target, got nil")
+		}
+	})
+
+	t.Run("symlink with dotdot target is created verbatim", func(t *testing.T) {
+		// A symlink whose target uses ".." must be stored verbatim, matching
+		// upstream kaniko and real container runtimes. Creating the link never
+		// follows the target; traversal is prevented when writing *through* a
+		// symlink (covered by "file through symlink is confined" below).
+		buf := makeTar(t, tar.Header{
+			Name: "ext-link", Typeflag: tar.TypeSymlink, Linkname: "../../etc/passwd",
+		})
+		dest := t.TempDir()
+		if _, err := UnTar(buf, dest); err != nil {
+			t.Fatalf("symlink with dotdot target should be created, not rejected: %v", err)
+		}
+		target, err := os.Readlink(filepath.Join(dest, "ext-link"))
+		if err != nil {
+			t.Fatalf("symlink was not created: %v", err)
+		}
+		if target != "../../etc/passwd" {
+			t.Fatalf("symlink target = %q, want %q (stored verbatim)", target, "../../etc/passwd")
+		}
+	})
+
+	t.Run("file through symlink is confined", func(t *testing.T) {
+		outsideDir := t.TempDir()
+		dest := t.TempDir()
+
+		// Tar contains a symlink pointing to an absolute path outside dest,
+		// followed by a file written under that symlink name.
+		buf := makeTar(t,
+			tar.Header{
+				Name: "extlink", Typeflag: tar.TypeSymlink, Linkname: outsideDir,
+			},
+			tar.Header{
+				Name: "extlink/written.txt", Size: 5, Mode: 0o644, Typeflag: tar.TypeReg,
+				Uid: os.Getuid(), Gid: os.Getgid(),
+			},
+		)
+		if _, err := UnTar(buf, dest); err != nil {
+			t.Fatalf("extraction should succeed (confined), got: %v", err)
+		}
+		// The file must not escape, and must land at the confined in-dest path.
+		if _, err := os.Stat(filepath.Join(outsideDir, "written.txt")); err == nil {
+			t.Fatal("file was written outside dest through symlink")
+		}
+		confined := filepath.Join(dest, outsideDir, "written.txt")
+		if _, err := os.Stat(confined); err != nil {
+			t.Fatalf("write was not confined to dest as expected (%s): %v", confined, err)
+		}
+	})
+
+	t.Run("write through deep relative escaping symlink is confined", func(t *testing.T) {
+		// The strongest version of the attack the removed lexical target check
+		// nominally guarded against: a deep relative symlink that escapes the
+		// root, followed by a write through it. The symlink is now created
+		// verbatim, but SecureJoin on the parent of the second entry clamps the
+		// ".." at the destination root, so the write stays inside dest.
+		outsideDir := t.TempDir() // sibling of dest, must remain untouched
+		marker := filepath.Join(outsideDir, "pwned.txt")
+		dest := t.TempDir()
+		buf := makeTar(t,
+			tar.Header{
+				Name: "evil", Typeflag: tar.TypeSymlink, Linkname: "../../../../../../../../../.." + outsideDir,
+			},
+			tar.Header{
+				Name: "evil/pwned.txt", Size: 5, Mode: 0o644, Typeflag: tar.TypeReg,
+				Uid: os.Getuid(), Gid: os.Getgid(),
+			},
+		)
+		if _, err := UnTar(buf, dest); err != nil {
+			t.Fatalf("extraction should succeed (confined), got: %v", err)
+		}
+		if _, err := os.Stat(marker); err == nil {
+			t.Fatalf("file escaped to %s through deep relative symlink", marker)
+		}
+		// SecureJoin clamps the ".." at the dest root, so the write must land at
+		// the confined in-dest location rather than escaping.
+		confined := filepath.Join(dest, outsideDir, "pwned.txt")
+		if _, err := os.Stat(confined); err != nil {
+			t.Fatalf("write was not confined to dest as expected (%s): %v", confined, err)
 		}
 	})
 


### PR DESCRIPTION
Fixes #560

Picks up the SecureJoin tar extraction from chainguard https://github.com/chainguard-dev/kaniko/pull/440. We sat on this because their fix was broken, it rejected legit base images whose symlinks use more `..` than their depth (Corretto-via-RPM cacerts) and earlier made `dash -> dash` loops. That is sorted now so it should be good. Each entry's parent is resolved with SecureJoin, so an escaping symlink in a malicious base image stays contained inside the destination instead of overwriting `/kaniko/tini` and getting RCE.

Gated behind `FF_KANIKO_SECUREJOIN_EXTRACTION`, but default on from the start, skipping our usual 2 week soak because it is a security fix.