### PR TITLE
linter: nakedret

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -271,9 +271,10 @@ func TestExpectError(t *testing.T) {
 	}
 }
 
-func getBranchCommitAndURL() (branch, commit, url string) {
+func getBranchCommitAndURL() (string, string, string) {
 	repo := os.Getenv("GITHUB_REPOSITORY")
-	commit = os.Getenv("GITHUB_SHA")
+	commit := os.Getenv("GITHUB_SHA")
+	branch := ""
 	if _, isPR := os.LookupEnv("GITHUB_HEAD_REF"); isPR {
 		branch = "main"
 	} else {
@@ -288,8 +289,8 @@ func getBranchCommitAndURL() (branch, commit, url string) {
 		branch = "main"
 	}
 	log.Printf("repo=%q / commit=%q / branch=%q", repo, commit, branch)
-	url = "github.com/" + repo
-	return
+	url := "github.com/" + repo
+	return branch, commit, url
 }
 
 func DockerGitRepo(url string, commit string, branch string) string {

--- a/pkg/buildcontext/git_test.go
+++ b/pkg/buildcontext/git_test.go
@@ -28,21 +28,19 @@ import (
 func TestGetGitPullMethod(t *testing.T) {
 	tests := []struct {
 		testName string
-		setEnv   func() (expectedValue string)
+		setEnv   func() string
 	}{
 		{
 			testName: "noEnv",
 			setEnv: func() (expectedValue string) {
-				expectedValue = gitPullMethodHTTPS
-				return
+				return gitPullMethodHTTPS
 			},
 		},
 		{
 			testName: "emptyEnv",
 			setEnv: func() (expectedValue string) {
 				_ = os.Setenv(gitPullMethodEnvKey, "")
-				expectedValue = gitPullMethodHTTPS
-				return
+				return gitPullMethodHTTPS
 			},
 		},
 		{
@@ -50,27 +48,24 @@ func TestGetGitPullMethod(t *testing.T) {
 			setEnv: func() (expectedValue string) {
 				err := os.Setenv(gitPullMethodEnvKey, gitPullMethodHTTP)
 				if nil != err {
-					expectedValue = gitPullMethodHTTPS
+					return gitPullMethodHTTPS
 				} else {
-					expectedValue = gitPullMethodHTTP
+					return gitPullMethodHTTP
 				}
-				return
 			},
 		},
 		{
 			testName: "httpsEnv",
 			setEnv: func() (expectedValue string) {
 				_ = os.Setenv(gitPullMethodEnvKey, gitPullMethodHTTPS)
-				expectedValue = gitPullMethodHTTPS
-				return
+				return gitPullMethodHTTPS
 			},
 		},
 		{
 			testName: "unknownEnv",
 			setEnv: func() (expectedValue string) {
 				_ = os.Setenv(gitPullMethodEnvKey, "unknown")
-				expectedValue = gitPullMethodHTTPS
-				return
+				return gitPullMethodHTTPS
 			},
 		},
 	}
@@ -86,29 +81,26 @@ func TestGetGitPullMethod(t *testing.T) {
 func TestGetGitAuth(t *testing.T) {
 	tests := []struct {
 		testName string
-		setEnv   func() (expectedValue transport.AuthMethod)
+		setEnv   func() transport.AuthMethod
 	}{
 		{
 			testName: "noEnv",
 			setEnv: func() (expectedValue transport.AuthMethod) {
-				expectedValue = nil
-				return
+				return nil
 			},
 		},
 		{
 			testName: "emptyUsernameEnv",
 			setEnv: func() (expectedValue transport.AuthMethod) {
 				_ = os.Setenv(gitAuthUsernameEnvKey, "")
-				expectedValue = nil
-				return
+				return nil
 			},
 		},
 		{
 			testName: "emptyPasswordEnv",
 			setEnv: func() (expectedValue transport.AuthMethod) {
 				_ = os.Setenv(gitAuthPasswordEnvKey, "")
-				expectedValue = nil
-				return
+				return nil
 			},
 		},
 		{
@@ -116,8 +108,7 @@ func TestGetGitAuth(t *testing.T) {
 			setEnv: func() (expectedValue transport.AuthMethod) {
 				_ = os.Setenv(gitAuthUsernameEnvKey, "")
 				_ = os.Setenv(gitAuthPasswordEnvKey, "")
-				expectedValue = nil
-				return
+				return nil
 			},
 		},
 		{
@@ -125,8 +116,7 @@ func TestGetGitAuth(t *testing.T) {
 			setEnv: func() (expectedValue transport.AuthMethod) {
 				username := "foo"
 				_ = os.Setenv(gitAuthUsernameEnvKey, username)
-				expectedValue = &http.BasicAuth{Username: username}
-				return
+				return &http.BasicAuth{Username: username}
 			},
 		},
 		{
@@ -134,8 +124,7 @@ func TestGetGitAuth(t *testing.T) {
 			setEnv: func() (expectedValue transport.AuthMethod) {
 				pass := "super-secret-password-1234"
 				_ = os.Setenv(gitAuthPasswordEnvKey, pass)
-				expectedValue = &http.BasicAuth{Password: pass}
-				return
+				return &http.BasicAuth{Password: pass}
 			},
 		},
 		{
@@ -145,8 +134,7 @@ func TestGetGitAuth(t *testing.T) {
 				pass := "super-secret-password-1234"
 				_ = os.Setenv(gitAuthUsernameEnvKey, username)
 				_ = os.Setenv(gitAuthPasswordEnvKey, pass)
-				expectedValue = &http.BasicAuth{Username: username, Password: pass}
-				return
+				return &http.BasicAuth{Username: username, Password: pass}
 			},
 		},
 		{
@@ -154,8 +142,7 @@ func TestGetGitAuth(t *testing.T) {
 			setEnv: func() (expectedValue transport.AuthMethod) {
 				token := "some-other-token"
 				_ = os.Setenv(gitAuthTokenEnvKey, token)
-				expectedValue = &http.BasicAuth{Username: token}
-				return
+				return &http.BasicAuth{Username: token}
 			},
 		},
 		{
@@ -167,8 +154,7 @@ func TestGetGitAuth(t *testing.T) {
 				_ = os.Setenv(gitAuthUsernameEnvKey, username)
 				_ = os.Setenv(gitAuthPasswordEnvKey, pass)
 				_ = os.Setenv(gitAuthTokenEnvKey, token)
-				expectedValue = &http.BasicAuth{Username: token}
-				return
+				return &http.BasicAuth{Username: token}
 			},
 		},
 	}

--- a/pkg/buildcontext/https.go
+++ b/pkg/buildcontext/https.go
@@ -35,7 +35,7 @@ type HTTPSTar struct {
 }
 
 // UnpackTarFromBuildContext downloads context file from https server
-func (h *HTTPSTar) UnpackTarFromBuildContext() (directory string, err error) {
+func (h *HTTPSTar) UnpackTarFromBuildContext() (directory string, retErr error) {
 	logrus.Info("Retrieving https tar file")
 
 	// Create directory and target file for downloading the context file
@@ -43,37 +43,39 @@ func (h *HTTPSTar) UnpackTarFromBuildContext() (directory string, err error) {
 	tarPath := filepath.Join(directory, constants.ContextTar)
 	file, err := util.CreateTargetTarfile(tarPath)
 	if err != nil {
-		return
+		return "", err
 	}
 
 	// Download tar file from remote https server
 	// and save it into the target tar file
 	resp, err := http.Get(h.context) //nolint:noctx
 	if err != nil {
-		return
+		return "", err
 	}
-	defer func() {
-		if closeErr := resp.Body.Close(); err == nil && closeErr != nil {
-			err = closeErr
-		}
-	}()
+	defer assignIfNil(&retErr, resp.Body.Close)
 
 	if resp.StatusCode != http.StatusOK {
-		return directory, fmt.Errorf("HTTPSTar bad status from server: %s", resp.Status)
+		return "", fmt.Errorf("HTTPSTar bad status from server: %s", resp.Status)
 	}
 
 	if _, err = io.Copy(file, resp.Body); err != nil {
-		return tarPath, err
+		return "", err
 	}
 
 	logrus.Info("Retrieved https tar file")
 
 	if err = util.UnpackCompressedTar(tarPath, directory); err != nil {
-		return
+		return "", err
 	}
 
 	logrus.Info("Extracted https tar file")
 
 	// Remove the tar so it doesn't interfere with subsequent commands
 	return directory, os.Remove(tarPath)
+}
+
+func assignIfNil(dst *error, fn func() error) {
+	if err := fn(); err != nil && *dst == nil {
+		*dst = err
+	}
 }

--- a/pkg/buildcontext/https.go
+++ b/pkg/buildcontext/https.go
@@ -45,6 +45,7 @@ func (h *HTTPSTar) UnpackTarFromBuildContext() (directory string, retErr error) 
 	if err != nil {
 		return "", err
 	}
+	defer assignIfNil(&retErr, file.Close)
 
 	// Download tar file from remote https server
 	// and save it into the target tar file

--- a/pkg/filesystem/resolve.go
+++ b/pkg/filesystem/resolve.go
@@ -35,10 +35,11 @@ import (
 // * If path is a symlink, resolve it's target. If the target is not ignored add it to the
 // output set.
 // * Add all ancestors of each path to the output set.
-func ResolvePaths(paths []string, wl []util.IgnoreListEntry) (pathsToAdd []string, err error) {
+func ResolvePaths(paths []string, wl []util.IgnoreListEntry) ([]string, error) {
 	logrus.Tracef("Resolving paths %s", paths)
 
 	fileSet := make(map[string]bool)
+	pathsToAdd := []string{}
 
 	for _, f := range paths {
 		// If the given path is part of the ignorelist ignore it
@@ -69,7 +70,7 @@ func ResolvePaths(paths []string, wl []util.IgnoreListEntry) (pathsToAdd []strin
 		if e != nil {
 			if !os.IsNotExist(e) {
 				logrus.Errorf("Couldn't eval %s with link %s", f, link)
-				return
+				return nil, e
 			}
 
 			logrus.Tracef("Symlink path %s, target does not exist", f)
@@ -94,7 +95,7 @@ func ResolvePaths(paths []string, wl []util.IgnoreListEntry) (pathsToAdd []strin
 
 	// Also add parent directories to keep the permission of them correctly.
 	pathsToAdd = filesWithParentDirs(pathsToAdd)
-	return
+	return pathsToAdd, nil
 }
 
 // filesWithParentDirs returns every ancestor path for each provided file path.


### PR DESCRIPTION
Carves the naked-return cleanup out of #539. Naked returns are rewritten to explicit `return x, err` form, generated by golangci-lint's nakedret fixer and behaviour-preserving (each return keeps the same named-return values it had implicitly). The nakedret linter itself is deliberately not enabled in the config here, that stays in #539 for now, so this is a pure code cleanup with no CI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Git metadata retrieval so callers receive the computed branch, commit, and URL.
  * Improved HTTPS build-context tar unpacking so failures return a consistent empty result and the correct error; response-body close errors are handled more reliably.
  * Corrected path resolution to explicitly return resolved paths and propagate non-ignorable symlink evaluation errors.
* **Tests**
  * Updated table-driven test helpers to use explicit return values for clearer, consistent expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->