### PR TITLE
linter: unused-parameter

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -117,7 +117,7 @@ func ValidateFlags(opts *config.KanikoOptions) {
 // RootCmd is the kaniko command that is run
 var RootCmd = &cobra.Command{
 	Use: "executor",
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 		if cmd.Use == "executor" {
 
 			if err := logging.Configure(logLevel, logFormat, logTimestamp); err != nil {
@@ -186,7 +186,7 @@ var RootCmd = &cobra.Command{
 		}
 		return nil
 	},
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		if !checkContained() {
 			if !force {
 				exit(errors.New("kaniko should only be run inside of a container, run with the --force flag if you are sure you want to continue"))

--- a/cmd/executor/cmd/root_test.go
+++ b/cmd/executor/cmd/root_test.go
@@ -120,7 +120,7 @@ func TestResolveEnvironmentBuildArgs(t *testing.T) {
 			description: "do not replace when environment variable is present and value is specified",
 			input:       []string{"variable1=value1", "variable2=value2"},
 			expected:    []string{"variable1=value1", "variable2=value2"},
-			mockedEnvironmentResolver: func(variable string) string {
+			mockedEnvironmentResolver: func(_ string) string {
 				return "unexpected"
 			},
 		},
@@ -128,7 +128,7 @@ func TestResolveEnvironmentBuildArgs(t *testing.T) {
 			description: "do not replace when environment variable is present and empty value is specified",
 			input:       []string{"variable1="},
 			expected:    []string{"variable1="},
-			mockedEnvironmentResolver: func(variable string) string {
+			mockedEnvironmentResolver: func(_ string) string {
 				return "unexpected"
 			},
 		},
@@ -136,7 +136,7 @@ func TestResolveEnvironmentBuildArgs(t *testing.T) {
 			description: "replace with empty value when environment variable is not present or empty and value is not specified",
 			input:       []string{"variable1", "variable2=value2"},
 			expected:    []string{"variable1=", "variable2=value2"},
-			mockedEnvironmentResolver: func(variable string) string {
+			mockedEnvironmentResolver: func(_ string) string {
 				return ""
 			},
 		},

--- a/cmd/executor/cmd/version.go
+++ b/cmd/executor/cmd/version.go
@@ -30,7 +30,7 @@ func init() {
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of kaniko",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		fmt.Println("Kaniko version : ", version.Version())
 	},
 }

--- a/cmd/warmer/cmd/root.go
+++ b/cmd/warmer/cmd/root.go
@@ -54,7 +54,7 @@ func init() {
 
 var RootCmd = &cobra.Command{
 	Use: "cache warmer",
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 		if err := logging.Configure(logLevel, logFormat, logTimestamp); err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ var RootCmd = &cobra.Command{
 
 		return nil
 	},
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		if _, err := os.Stat(opts.CacheDir); os.IsNotExist(err) {
 			err = os.MkdirAll(opts.CacheDir, 0o755)
 			if err != nil {

--- a/integration/tar.go
+++ b/integration/tar.go
@@ -67,7 +67,7 @@ func tarballOfDirectory(pathToDir string, f io.Writer) error {
 	tarWriter := util.NewTar(f)
 	defer tarWriter.Close()
 
-	walkFn := func(path string, d fs.DirEntry, err error) error {
+	walkFn := func(path string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/pkg/buildcontext/https_test.go
+++ b/pkg/buildcontext/https_test.go
@@ -29,7 +29,7 @@ func TestBuildWithHttpsTar(t *testing.T) {
 	}{
 		{
 			name: "test http bad status",
-			serverHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			serverHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
 				_, err := w.Write([]byte("corrupted message"))
 				if err != nil {
@@ -39,7 +39,7 @@ func TestBuildWithHttpsTar(t *testing.T) {
 		},
 		{
 			name: "test http bad data",
-			serverHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			serverHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, err := w.Write([]byte("corrupted message"))
 				if err != nil {

--- a/pkg/commands/add.go
+++ b/pkg/commands/add.go
@@ -168,7 +168,7 @@ type CachingAddCommand struct {
 	extractFn      util.ExtractFunction
 }
 
-func (ca *CachingAddCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
+func (ca *CachingAddCommand) ExecuteCommand(_ *v1.Config, _ *dockerfile.BuildArgs) error {
 	logrus.Infof("Found cached layer, extracting to filesystem")
 	var err error
 

--- a/pkg/commands/cmd.go
+++ b/pkg/commands/cmd.go
@@ -32,7 +32,7 @@ type CmdCommand struct {
 
 // ExecuteCommand executes the CMD command
 // Argument handling is the same as RUN.
-func (c *CmdCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
+func (c *CmdCommand) ExecuteCommand(config *v1.Config, _ *dockerfile.BuildArgs) error {
 	var newCommand []string
 	if c.cmd.PrependShell {
 		// This is the default shell on Linux

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -226,7 +226,7 @@ type CachingCopyCommand struct {
 	extractFn      util.ExtractFunction
 }
 
-func (cr *CachingCopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
+func (cr *CachingCopyCommand) ExecuteCommand(_ *v1.Config, _ *dockerfile.BuildArgs) error {
 	logrus.Infof("Found cached layer, extracting to filesystem")
 	var err error
 

--- a/pkg/commands/copy_test.go
+++ b/pkg/commands/copy_test.go
@@ -1042,7 +1042,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 		uid := os.Getuid()
 		gid := os.Getgid()
 
-		getActiveUserGroup = func(userStr string, chownStr string, _ []string) (int64, int64, error) {
+		getActiveUserGroup = func(_ string, _ string, _ []string) (int64, int64, error) {
 			return int64(uid), int64(gid), nil
 		}
 
@@ -1087,7 +1087,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 		original := getActiveUserGroup
 		defer func() { getActiveUserGroup = original }()
 
-		getActiveUserGroup = func(userStr string, chownStr string, _ []string) (int64, int64, error) {
+		getActiveUserGroup = func(_ string, _ string, _ []string) (int64, int64, error) {
 			return 12345, 12345, nil
 		}
 

--- a/pkg/commands/entrypoint.go
+++ b/pkg/commands/entrypoint.go
@@ -30,7 +30,7 @@ type EntrypointCommand struct {
 }
 
 // ExecuteCommand handles command processing similar to CMD and RUN,
-func (e *EntrypointCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
+func (e *EntrypointCommand) ExecuteCommand(config *v1.Config, _ *dockerfile.BuildArgs) error {
 	var newCommand []string
 	if e.cmd.PrependShell {
 		// This is the default shell on Linux

--- a/pkg/commands/healthcheck.go
+++ b/pkg/commands/healthcheck.go
@@ -39,7 +39,7 @@ type HealthCheckCommand struct {
 }
 
 // ExecuteCommand handles command processing similar to CMD and RUN,
-func (h *HealthCheckCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
+func (h *HealthCheckCommand) ExecuteCommand(config *v1.Config, _ *dockerfile.BuildArgs) error {
 	check := convertDockerHealthConfigToContainerRegistryFormat(*h.cmd.Health)
 	config.Healthcheck = &check
 

--- a/pkg/commands/onbuild.go
+++ b/pkg/commands/onbuild.go
@@ -29,7 +29,7 @@ type OnBuildCommand struct {
 }
 
 // ExecuteCommand adds the specified expression in Onbuild to the config
-func (o *OnBuildCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
+func (o *OnBuildCommand) ExecuteCommand(config *v1.Config, _ *dockerfile.BuildArgs) error {
 	logrus.Info("Cmd: ONBUILD")
 	logrus.Infof("Args: %s", o.cmd.Expression)
 	if config.OnBuild == nil {

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -471,7 +471,7 @@ func (cr *CachingRunCommand) IsArgsEnvsRequiredInCache() bool {
 	return true
 }
 
-func (cr *CachingRunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
+func (cr *CachingRunCommand) ExecuteCommand(_ *v1.Config, _ *dockerfile.BuildArgs) error {
 	logrus.Infof("Found cached layer, extracting to filesystem")
 	var err error
 

--- a/pkg/commands/run_test.go
+++ b/pkg/commands/run_test.go
@@ -113,7 +113,7 @@ func Test_addDefaultHOME(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			original := userLookup
-			userLookup = func(username string) (*user.User, error) { return test.mockUser, test.lookupError }
+			userLookup = func(_ string) (*user.User, error) { return test.mockUser, test.lookupError }
 			defer func() {
 				userLookup = original
 			}()

--- a/pkg/commands/shell.go
+++ b/pkg/commands/shell.go
@@ -28,7 +28,7 @@ type ShellCommand struct {
 }
 
 // ExecuteCommand handles command processing similar to CMD and RUN,
-func (s *ShellCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
+func (s *ShellCommand) ExecuteCommand(config *v1.Config, _ *dockerfile.BuildArgs) error {
 	config.Shell = s.cmd.Shell
 	return nil
 }

--- a/pkg/commands/workdir_test.go
+++ b/pkg/commands/workdir_test.go
@@ -83,7 +83,7 @@ var workdirTests = []struct {
 }
 
 // For testing
-func mockDir(path string, mode os.FileMode, uid, gid int64) error {
+func mockDir(_ string, _ os.FileMode, _, _ int64) error {
 	return nil
 }
 

--- a/pkg/creds/env_keychain.go
+++ b/pkg/creds/env_keychain.go
@@ -28,11 +28,11 @@ type envCredentialsHelper struct{}
 
 var EnvCredentialsHelper = &envCredentialsHelper{}
 
-func (ech *envCredentialsHelper) Add(c *credentials.Credentials) error {
+func (ech *envCredentialsHelper) Add(_ *credentials.Credentials) error {
 	return errors.New("unsupported operation")
 }
 
-func (ech *envCredentialsHelper) Delete(serverURL string) error {
+func (ech *envCredentialsHelper) Delete(_ string) error {
 	return errors.New("unsupported operation")
 }
 

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -92,7 +92,7 @@ func baseImageIndex(currentStage int, stages []instructions.Stage) int {
 	return -1
 }
 
-func lintWarnFunc(rulename, description, url, fmtmsg string, location []parser.Range) {
+func lintWarnFunc(rulename, _, url, fmtmsg string, location []parser.Range) {
 	if len(location) > 0 {
 		logrus.Warnf("%s: %s (line %d)\n\t%s", rulename, fmtmsg, location[0].Start.Line, url)
 	} else {

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -340,7 +340,7 @@ COPY --from=second /bar /bat
 			defer func() {
 				dockerfile.GetRemoteOnBuild = original
 			}()
-			dockerfile.GetRemoteOnBuild = func(baseName string, metaArgs []instructions.ArgCommand, opts *config.KanikoOptions) ([]string, error) {
+			dockerfile.GetRemoteOnBuild = func(baseName string, _ []instructions.ArgCommand, _ *config.KanikoOptions) ([]string, error) {
 				switch baseName {
 				case "alpine":
 					// if image is "alpine" then add ONBUILD to its config
@@ -1411,7 +1411,7 @@ RUN foobar
 			opts:           &config.KanikoOptions{InitialFSUnpacked: true},
 			stage:          config.KanikoStage{Index: 0},
 			crossStageDeps: true,
-			mockGetFSFromImage: func(root string, img v1.Image, extract util.ExtractFunction) ([]string, error) {
+			mockGetFSFromImage: func(_ string, _ v1.Image, _ util.ExtractFunction) ([]string, error) {
 				return nil, errors.New("getFSFromImage shouldn't be called if fs is already unpacked")
 			},
 		},

--- a/pkg/executor/fakes_test.go
+++ b/pkg/executor/fakes_test.go
@@ -57,7 +57,7 @@ type MockDockerCommand struct {
 	argToCompositeCache bool
 }
 
-func (m MockDockerCommand) ExecuteCommand(c *v1.Config, args *dockerfile.BuildArgs) error { return nil }
+func (m MockDockerCommand) ExecuteCommand(_ *v1.Config, _ *dockerfile.BuildArgs) error { return nil }
 func (m MockDockerCommand) String() string {
 	return m.command
 }
@@ -70,11 +70,11 @@ func (m MockDockerCommand) ProvidesFilesToSnapshot() bool {
 	return true
 }
 
-func (m MockDockerCommand) CacheCommand(image v1.Image) commands.DockerCommand {
+func (m MockDockerCommand) CacheCommand(_ v1.Image) commands.DockerCommand {
 	return m.cacheCommand
 }
 
-func (m MockDockerCommand) FilesUsedFromContext(c *v1.Config, args *dockerfile.BuildArgs) ([]string, error) {
+func (m MockDockerCommand) FilesUsedFromContext(_ *v1.Config, _ *dockerfile.BuildArgs) ([]string, error) {
 	return m.contextFiles, nil
 }
 
@@ -103,7 +103,7 @@ type MockCachedDockerCommand struct {
 	argToCompositeCache bool
 }
 
-func (m MockCachedDockerCommand) ExecuteCommand(c *v1.Config, args *dockerfile.BuildArgs) error {
+func (m MockCachedDockerCommand) ExecuteCommand(_ *v1.Config, _ *dockerfile.BuildArgs) error {
 	return nil
 }
 
@@ -119,7 +119,7 @@ func (m MockCachedDockerCommand) ProvidesFilesToSnapshot() bool {
 	return true
 }
 
-func (m MockCachedDockerCommand) CacheCommand(image v1.Image) commands.DockerCommand {
+func (m MockCachedDockerCommand) CacheCommand(_ v1.Image) commands.DockerCommand {
 	return nil
 }
 
@@ -127,7 +127,7 @@ func (m MockCachedDockerCommand) ShouldDetectDeletedFiles() bool {
 	return false
 }
 
-func (m MockCachedDockerCommand) FilesUsedFromContext(c *v1.Config, args *dockerfile.BuildArgs) ([]string, error) {
+func (m MockCachedDockerCommand) FilesUsedFromContext(_ *v1.Config, _ *dockerfile.BuildArgs) ([]string, error) {
 	return m.contextFiles, nil
 }
 

--- a/pkg/executor/push_test.go
+++ b/pkg/executor/push_test.go
@@ -318,7 +318,7 @@ func resetCalledCount() {
 	checkPushPermsCallCount = 0
 }
 
-func fakeCheckPushPermission(ref name.Reference, kc authn.Keychain, t http.RoundTripper) error {
+func fakeCheckPushPermission(_ name.Reference, _ authn.Keychain, _ http.RoundTripper) error {
 	checkPushPermsCallCount++
 	return nil
 }
@@ -449,7 +449,7 @@ func TestSkipPushPermission(t *testing.T) {
 	}
 }
 
-func TestHelperProcess(t *testing.T) {
+func TestHelperProcess(_ *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
 	}

--- a/pkg/image/image_util_test.go
+++ b/pkg/image/image_util_test.go
@@ -50,7 +50,7 @@ func Test_StandardImage(t *testing.T) {
 	defer func() {
 		RetrieveRemoteImage = original
 	}()
-	mock := func(image string, opts config.RegistryOptions, _ string) (v1.Image, error) {
+	mock := func(_ string, _ config.RegistryOptions, _ string) (v1.Image, error) {
 		return nil, nil
 	}
 	RetrieveRemoteImage = mock
@@ -87,7 +87,7 @@ func Test_OciImage(t *testing.T) {
 	defer func() {
 		retrieveOciImage = original
 	}()
-	mock := func(index int) (v1.Image, error) {
+	mock := func(_ int) (v1.Image, error) {
 		return nil, nil
 	}
 	retrieveOciImage = mock

--- a/pkg/image/remote/remote_test.go
+++ b/pkg/image/remote/remote_test.go
@@ -194,7 +194,7 @@ func Test_RetrieveRemoteImage_skipFallback(t *testing.T) {
 		SkipDefaultRegistryFallback: false,
 	}
 
-	remoteImageFunc = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+	remoteImageFunc = func(ref name.Reference, _ ...remote.Option) (v1.Image, error) {
 		if ref.Context().Registry.Name() == registryMirror {
 			return nil, errors.New("no image found")
 		}
@@ -220,7 +220,7 @@ func Test_RetryRetrieveRemoteImageSucceeds(t *testing.T) {
 		ImageDownloadRetry: 2,
 	}
 	attempts := 0
-	remoteImageFunc = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+	remoteImageFunc = func(_ name.Reference, _ ...remote.Option) (v1.Image, error) {
 		if attempts < 2 {
 			attempts++
 			return nil, errors.New("no image found")
@@ -241,7 +241,7 @@ func Test_NoRetryRetrieveRemoteImageFails(t *testing.T) {
 		ImageDownloadRetry: 0,
 	}
 	attempts := 0
-	remoteImageFunc = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+	remoteImageFunc = func(_ name.Reference, _ ...remote.Option) (v1.Image, error) {
 		if attempts < 1 {
 			attempts++
 			return nil, errors.New("no image found")

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -98,7 +98,7 @@ func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string,
 	// Get whiteout paths
 	var filesToWhiteout []string
 	if shdCheckDelete {
-		_, deletedFiles, err := util.WalkFS(s.directory, s.l.GetCurrentPaths(), func(s string) (bool, error) {
+		_, deletedFiles, err := util.WalkFS(s.directory, s.l.GetCurrentPaths(), func(_ string) (bool, error) {
 			return true, nil
 		})
 		if err != nil {

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -546,7 +546,7 @@ func IsInIgnoreList(path string) bool {
 	return IsInProvidedIgnoreList(path, ignorelist)
 }
 
-func CheckCleanedPathAgainstProvidedIgnoreList(path string, wl []IgnoreListEntry) bool {
+func CheckCleanedPathAgainstProvidedIgnoreList(path string, _ []IgnoreListEntry) bool {
 	for _, wl := range ignorelist {
 		if hasCleanedFilepathPrefix(path, wl.Path, wl.PrefixMatchOnly) {
 			return true
@@ -970,7 +970,7 @@ func CopyFile(src, dest string, context FileContext, uid, gid int64, chmod mode.
 	return false, CopyCapabilities(src, dest)
 }
 
-func CopyFileInternal(src, dest string, context FileContext) error {
+func CopyFileInternal(src, dest string, _ FileContext) error {
 	fi, err := os.Stat(src)
 	if err != nil {
 		return err
@@ -1204,7 +1204,7 @@ func CopyFileOrSymlink(src string, destDir string, root string) error {
 	}
 	opts := otiai10Cpy.Options{
 		PreserveTimes: true,
-		Skip: func(info os.FileInfo, src, dest string) (bool, error) {
+		Skip: func(_ os.FileInfo, src, _ string) (bool, error) {
 			return strings.HasSuffix(src, config.KanikoDir), nil
 		},
 		FS: FSys,

--- a/pkg/util/transport_util_test.go
+++ b/pkg/util/transport_util_test.go
@@ -41,7 +41,7 @@ func (m *mockedCertPool) append(path string) error {
 
 type mockedKeyPairLoader struct{}
 
-func (p *mockedKeyPairLoader) load(certFile, keyFile string) (tls.Certificate, error) {
+func (p *mockedKeyPairLoader) load(_, _ string) (tls.Certificate, error) {
 	foo := tls.Certificate{}
 	return foo, nil
 }
@@ -57,7 +57,7 @@ func Test_makeTransport(t *testing.T) {
 		{
 			name: "SkipTLSVerify set",
 			opts: config.RegistryOptions{SkipTLSVerify: true},
-			check: func(config *tls.Config, pool *mockedCertPool, err error) {
+			check: func(config *tls.Config, _ *mockedCertPool, _ error) {
 				if !config.InsecureSkipVerify {
 					t.Errorf("makeTransport().TLSClientConfig.InsecureSkipVerify not set while SkipTLSVerify set")
 				}
@@ -66,7 +66,7 @@ func Test_makeTransport(t *testing.T) {
 		{
 			name: "SkipTLSVerifyRegistries set with expected registry",
 			opts: config.RegistryOptions{SkipTLSVerifyRegistries: []string{registryName}},
-			check: func(config *tls.Config, pool *mockedCertPool, err error) {
+			check: func(config *tls.Config, _ *mockedCertPool, _ error) {
 				if !config.InsecureSkipVerify {
 					t.Errorf("makeTransport().TLSClientConfig.InsecureSkipVerify not set while SkipTLSVerifyRegistries set with registry name")
 				}
@@ -75,7 +75,7 @@ func Test_makeTransport(t *testing.T) {
 		{
 			name: "SkipTLSVerifyRegistries set with other registry",
 			opts: config.RegistryOptions{SkipTLSVerifyRegistries: []string{"other." + registryName}},
-			check: func(config *tls.Config, pool *mockedCertPool, err error) {
+			check: func(config *tls.Config, _ *mockedCertPool, _ error) {
 				if config.InsecureSkipVerify {
 					t.Errorf("makeTransport().TLSClientConfig.InsecureSkipVerify set while SkipTLSVerifyRegistries not set with registry name")
 				}
@@ -84,7 +84,7 @@ func Test_makeTransport(t *testing.T) {
 		{
 			name: "RegistriesCertificates set for registry",
 			opts: config.RegistryOptions{RegistriesCertificates: map[string]string{registryName: "/path/to/the/certificate.cert"}},
-			check: func(config *tls.Config, pool *mockedCertPool, err error) {
+			check: func(_ *tls.Config, pool *mockedCertPool, _ error) {
 				if len(pool.certificatesPath) != 1 || pool.certificatesPath[0] != "/path/to/the/certificate.cert" {
 					t.Errorf("makeTransport().RegistriesCertificates certificate not appended to system certificates")
 				}
@@ -93,7 +93,7 @@ func Test_makeTransport(t *testing.T) {
 		{
 			name: "RegistriesCertificates set for another registry",
 			opts: config.RegistryOptions{RegistriesCertificates: map[string]string{fmt.Sprintf("other.%s=", registryName): "/path/to/the/certificate.cert"}},
-			check: func(config *tls.Config, pool *mockedCertPool, err error) {
+			check: func(_ *tls.Config, pool *mockedCertPool, _ error) {
 				if len(pool.certificatesPath) != 0 {
 					t.Errorf("makeTransport().RegistriesCertificates certificate appended to system certificates while added for other registry")
 				}
@@ -102,7 +102,7 @@ func Test_makeTransport(t *testing.T) {
 		{
 			name: "RegistriesClientCertificates set for registry",
 			opts: config.RegistryOptions{RegistriesClientCertificates: map[string]string{registryName: "/path/to/client/certificate.cert,/path/to/client/key.key"}},
-			check: func(config *tls.Config, pool *mockedCertPool, err error) {
+			check: func(config *tls.Config, _ *mockedCertPool, _ error) {
 				if len(config.Certificates) != 1 {
 					t.Errorf("makeTransport().RegistriesClientCertificates not loaded for desired registry")
 				}
@@ -111,7 +111,7 @@ func Test_makeTransport(t *testing.T) {
 		{
 			name: "RegistriesClientCertificates set for another registry",
 			opts: config.RegistryOptions{RegistriesClientCertificates: map[string]string{"other." + registryName: "/path/to/client/certificate.cert,/path/to/key.key,/path/to/extra.crt"}},
-			check: func(config *tls.Config, pool *mockedCertPool, err error) {
+			check: func(config *tls.Config, _ *mockedCertPool, _ error) {
 				if len(config.Certificates) != 0 {
 					t.Errorf("makeTransport().RegistriesClientCertificates certificate loaded for other registry")
 				}
@@ -120,7 +120,7 @@ func Test_makeTransport(t *testing.T) {
 		{
 			name: "RegistriesClientCertificates incorrect cert format",
 			opts: config.RegistryOptions{RegistriesClientCertificates: map[string]string{registryName: "/path/to/client/certificate.cert"}},
-			check: func(config *tls.Config, pool *mockedCertPool, err error) {
+			check: func(config *tls.Config, _ *mockedCertPool, err error) {
 				if config != nil {
 					t.Errorf("makeTransport().RegistriesClientCertificates was incorrectly loaded without both client/key (config was not nil)")
 				}
@@ -135,7 +135,7 @@ func Test_makeTransport(t *testing.T) {
 		{
 			name: "RegistriesClientCertificates incorrect cert format extra",
 			opts: config.RegistryOptions{RegistriesClientCertificates: map[string]string{registryName: "/path/to/client/certificate.cert,/path/to/key.key,/path/to/extra.crt"}},
-			check: func(config *tls.Config, pool *mockedCertPool, err error) {
+			check: func(config *tls.Config, _ *mockedCertPool, err error) {
 				if config != nil {
 					t.Errorf("makeTransport().RegistriesClientCertificates was incorrectly loaded with extra paths in comma split (config was not nil)")
 				}
@@ -161,7 +161,7 @@ func Test_makeTransport(t *testing.T) {
 		}
 		systemCertLoader = certPool
 		systemKeyPairLoader = &mockedKeyPairLoader{}
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(_ *testing.T) {
 			tr, err := MakeTransport(tt.opts, registryName)
 			var tlsConfig *tls.Config
 			if err == nil {


### PR DESCRIPTION
Carves the unused-parameter cleanup out of #539. Unused named function parameters are renamed to `_` (e.g. the cobra `Run: func(_ *cobra.Command, _ []string)` handlers), as flagged by revive's unused-parameter rule. Purely mechanical and behaviour-preserving. The rule itself is not enabled in the config here, that stays in #539, so this is a code cleanup with no CI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Clarified unused callback and method parameters across command execution, image handling, filesystem utilities, and credential operations.
  * Preserved existing command, caching, snapshot, archive, and transport behavior.

* **Tests**
  * Updated test doubles and callbacks to accurately indicate ignored inputs.
  * Existing assertions, mocked results, and test behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->