### PR TITLE
linter: whitespace, modernize, ineffassign, wastedassign

### DIFF
--- a/integration/images.go
+++ b/integration/images.go
@@ -443,7 +443,6 @@ func FindDockerFiles(dir, dockerfilesPattern string) ([]string, error) {
 		// Remove the leading directory from the path
 		dockerfile = dockerfile[len("dockerfiles/"):]
 		dockerfiles = append(dockerfiles, dockerfile)
-
 	}
 	return dockerfiles, err
 }

--- a/pkg/buildcontext/tar.go
+++ b/pkg/buildcontext/tar.go
@@ -54,7 +54,6 @@ func (t *Tar) UnpackTarFromBuildContext() (string, error) {
 		_, err = util.UnTar(gzr, directory)
 
 		return directory, err
-
 	}
 
 	return directory, util.UnpackCompressedTar(t.context, directory)

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -47,7 +47,7 @@ type CopyCommand struct {
 
 func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
 	// Resolve from
-	uid, gid := int64(-1), int64(-1)
+	var uid, gid int64
 	var err error
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
 	if c.cmd.From != "" {

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -158,7 +158,6 @@ func runCommandWithFlags(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmd
 						return fmt.Errorf("environment variable for secret %q not set: %s", secretId, s.Src)
 					}
 					secretData = []byte(val)
-					val = ""
 				} else {
 					secretData, err = os.ReadFile(s.Src)
 					if err != nil {

--- a/pkg/commands/workdir.go
+++ b/pkg/commands/workdir.go
@@ -67,7 +67,6 @@ func (w *WorkdirCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile
 	// Only create and snapshot the dir if it didn't exist already
 	w.snapshotFiles = []string{}
 	if _, err := os.Stat(config.WorkingDir); os.IsNotExist(err) {
-
 		uid, gid, err := util.GetActiveUserGroup(config.User, "", replacementEnvs)
 		if err != nil {
 			return fmt.Errorf("getting user group: %w", err)

--- a/pkg/image/remote/remote.go
+++ b/pkg/image/remote/remote.go
@@ -51,7 +51,6 @@ func RetrieveRemoteImage(image string, opts config.RegistryOptions, customPlatfo
 
 	if newRegURLs, found := opts.RegistryMaps[ref.Context().RegistryStr()]; found {
 		for _, registryMapping := range newRegURLs {
-
 			regToMapTo, repositoryPrefix := parseRegistryMapping(registryMapping)
 
 			insecurePull := opts.InsecurePull || opts.InsecureRegistries.Contains(regToMapTo)

--- a/pkg/util/assert.go
+++ b/pkg/util/assert.go
@@ -31,7 +31,7 @@ func init() {
 		return
 	}
 	disabledAssertions = make(map[string]struct{})
-	for _, name := range strings.Split(val, ",") {
+	for name := range strings.SplitSeq(val, ",") {
 		name = strings.TrimSpace(name)
 		if name != "" {
 			disabledAssertions[name] = struct{}{}

--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -134,7 +134,6 @@ func Test_EnvReplacement(t *testing.T) {
 	for _, test := range testEnvReplacement {
 		actualPath, err := ResolveEnvironmentReplacement(test.path, test.envs, test.isFilepath)
 		testutil.CheckErrorAndDeepEqual(t, false, err, test.expectedPath, actualPath)
-
 	}
 }
 

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -240,7 +240,6 @@ func extractLayer(i int, l v1.Layer, root string, cfg *FSConfig) ([]string, erro
 				logrus.Trace("Not including whiteout files")
 				continue
 			}
-
 		}
 
 		if err := cfg.extractFunc(root, hdr, cleanedName, tr); err != nil {

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -766,7 +766,7 @@ func TestExtractFile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc := tc
 			t.Parallel()
-			r := ""
+			var r string
 
 			if tc.tmpdir != "" {
 				r = tc.tmpdir

--- a/pkg/util/transport_util_test.go
+++ b/pkg/util/transport_util_test.go
@@ -169,6 +169,5 @@ func Test_makeTransport(t *testing.T) {
 			}
 			tt.check(tlsConfig, certPool, err)
 		})
-
 	}
 }


### PR DESCRIPTION
Bundles four small, mechanical, easy-to-review linter cleanups carved from #539 (kept together since each is trivial):
- whitespace: drop unnecessary leading/trailing blank lines in function bodies
- modernize: `strings.Split` range loop becomes `strings.SplitSeq`
- ineffassign / wastedassign: remove assignments overwritten before use (`uid, gid := -1, -1`, `val = ""`, `r := ""` become plain `var` or are removed)

All behaviour-preserving and generated/derived from golangci-lint. The linters themselves are not enabled in the config here, that stays in #539.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Missing environment variables referenced by secret mounts now produce a clear error instead of creating an empty secret.
  - Errors encountered while unpacking build contexts are now correctly propagated.
  - Improved handling of assertion configuration and file extraction edge cases.

- **Tests**
  - Corrected test control flow and variable initialization to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->