### PR TITLE
linter: modernize

### DIFF
--- a/pkg/util/assert.go
+++ b/pkg/util/assert.go
@@ -31,7 +31,7 @@ func init() {
 		return
 	}
 	disabledAssertions = make(map[string]struct{})
-	for _, name := range strings.Split(val, ",") {
+	for name := range strings.SplitSeq(val, ",") {
 		name = strings.TrimSpace(name)
 		if name != "" {
 			disabledAssertions[name] = struct{}{}


### PR DESCRIPTION
Carves a residual modernize finding out of #539: `strings.Split` range loop becomes `strings.SplitSeq` (Go 1.24). Mechanical, generated by golangci-lint --fix. Not enabled in the config here, that stays in #539.