### PR TITLE
linter: ineffassign

### DIFF
--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -47,7 +47,7 @@ type CopyCommand struct {
 
 func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
 	// Resolve from
-	uid, gid := int64(-1), int64(-1)
+	var uid, gid int64
 	var err error
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
 	if c.cmd.From != "" {

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -158,7 +158,6 @@ func runCommandWithFlags(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmd
 						return fmt.Errorf("environment variable for secret %q not set: %s", secretId, s.Src)
 					}
 					secretData = []byte(val)
-					val = ""
 				} else {
 					secretData, err = os.ReadFile(s.Src)
 					if err != nil {


### PR DESCRIPTION
Carves the ineffassign findings out of #539. Two ineffectual assignments removed: copy.go's `uid, gid := -1, -1` (overwritten in every branch before use, now `var uid, gid int64`) and run.go's `val = ""` (a no-op, Go strings are immutable so it clears nothing; the secret is nulled via `secretData`). Behaviour-preserving. Not enabled in the config here, that stays in #539.