### PR TITLE
linter: wastedassign

### DIFF
--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -47,7 +47,7 @@ type CopyCommand struct {
 
 func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
 	// Resolve from
-	uid, gid := int64(-1), int64(-1)
+	var uid, gid int64
 	var err error
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
 	if c.cmd.From != "" {

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -158,7 +158,6 @@ func runCommandWithFlags(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmd
 						return fmt.Errorf("environment variable for secret %q not set: %s", secretId, s.Src)
 					}
 					secretData = []byte(val)
-					val = ""
 				} else {
 					secretData, err = os.ReadFile(s.Src)
 					if err != nil {

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -766,7 +766,7 @@ func TestExtractFile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc := tc
 			t.Parallel()
-			r := ""
+			var r string
 
 			if tc.tmpdir != "" {
 				r = tc.tmpdir


### PR DESCRIPTION
Carves the wastedassign findings out of #539. Three assignments that are overwritten before use are dropped: copy.go's `uid, gid := -1, -1`, run.go's `val = ""`, and a test's `r := ""` (all become plain `var` declarations or are removed). Behaviour-preserving. Overlaps the ineffassign PR #831-family on the copy.go/run.go lines, which is fine to reconcile at merge. Not enabled in the config here, that stays in #539.