### PR TITLE
docs: remove dangling FF_KANIKO_COPY_CACHEKEY_FOLD_ARGS TOC entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ expect - see [Known Issues](#known-issues).
       - [Flag `FF_KANIKO_REPRODUCIBLE_PRESERVE_BASE_LAYERS`](#flag-ff_kaniko_reproducible_preserve_base_layers)
       - [Flag `FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE`](#flag-ff_kaniko_deprecate_inter_stage_restore)
       - [Flag `FF_KANIKO_SCOPED_DOCKERIGNORE`](#flag-ff_kaniko_scoped_dockerignore)
-      - [Flag `FF_KANIKO_COPY_CACHEKEY_FOLD_ARGS`](#flag-ff_kaniko_copy_cachekey_fold_args)
       - [Flag `FF_KANIKO_SKIP_RELABEL_RECOMPRESS`](#flag-ff_kaniko_skip_relabel_recompress)
       - [Flag `FF_KANIKO_SECUREJOIN_EXTRACTION`](#flag-ff_kaniko_securejoin_extraction)
       - [Flag `FF_KANIKO_RESOLVE_CACHE_KEY`](#flag-ff_kaniko_resolve_cache_key)


### PR DESCRIPTION
Amends #801, which renamed `FF_KANIKO_COPY_CACHEKEY_FOLD_ARGS` to `FF_KANIKO_RESOLVE_CACHE_KEY` (section header and code) but missed the old README table-of-contents entry. That left a TOC link to `#flag-ff_kaniko_copy_cachekey_fold_args`, an anchor that no longer exists. Removes the dangling entry.