### PR TITLE
mz841: ADD applies the tar root entry to the destination dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `FF_KANIKO_SKIP_RELABEL_RECOMPRESS`](#flag-ff_kaniko_skip_relabel_recompress)
       - [Flag `FF_KANIKO_SECUREJOIN_EXTRACTION`](#flag-ff_kaniko_securejoin_extraction)
       - [Flag `FF_KANIKO_RESOLVE_CACHE_KEY`](#flag-ff_kaniko_resolve_cache_key)
+      - [Flag `FF_KANIKO_UNTAR_SKIP_ROOT`](#flag-ff_kaniko_untar_skip_root)
     - [Assertion Overrides](#assertion-overrides)
     - [Debug Image](#debug-image)
   - [Security](#security)
@@ -1316,6 +1317,13 @@ When unpacking image layers kaniko joins each tar entry path lexically, so a mal
 Set this flag to `true` to resolve each entry's parent with SecureJoin so the write stays contained inside the destination.
 Defaults to `true`.
 Will be deprecated in `v1.29.0`.
+
+#### Flag `FF_KANIKO_UNTAR_SKIP_ROOT`
+
+When `ADD` extracts a local tar archive into a directory, kaniko applies the archive's root `.` entry to the destination directory and overwrites its mode and ownership, while docker leaves the destination untouched.
+Set this flag to `true` to skip the root `.` entry when untarring.
+Defaults to `false`.
+Becomes default in `v1.29.0`.
 
 ### Assertion Overrides
 

--- a/integration/dockerfiles/Dockerfile_test_issue_mz841
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz841
@@ -1,0 +1,5 @@
+# mz841: ADD of a local tar applies the archive root "." entry to the destination
+# dir, so /target flips from 0700 to 0755 on v1.27.6. docker ignores the root entry.
+FROM alpine:3.20
+RUN mkdir -m 0700 /target
+ADD context/tars/file.tar /target/

--- a/integration/images.go
+++ b/integration/images.go
@@ -118,6 +118,7 @@ var KanikoEnv = []string{
 	"FF_KANIKO_REPRODUCIBLE_PRESERVE_BASE_LAYERS=1",
 	"FF_KANIKO_SCOPED_DOCKERIGNORE=1",
 	"FF_KANIKO_RESOLVE_CACHE_KEY=1",
+	"FF_KANIKO_UNTAR_SKIP_ROOT=1",
 	"KANIKO_PRINT_PLAN=1",
 }
 
@@ -250,8 +251,6 @@ var diffArgsMap = map[string][]string{
 	// docker is wrong. we do copy the symlink correctly.
 	"TestRun/test_Dockerfile_test_copy_symlink": {"--extra-ignore-files=workdirAnother/relative_link"},
 	"TestRun/test_Dockerfile_test_multistage":   {"--extra-ignore-files=new"},
-	// when we untar we overwrite the parent directory, buildkit doesnt
-	"TestRun/test_Dockerfile_test_add": {"--extra-ignore-file-permissions"},
 	// Verify we don't store root directory
 	"TestRun/test_Dockerfile_test_root":          {"--extra-ignore-layer-length-mismatch=false"},
 	"TestRun/test_Dockerfile_test_cross_compile": {"--platform=linux/" + crossCompileArch},

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -347,6 +347,9 @@ func UnTar(r io.Reader, dest string) ([]string, error) {
 			return nil, err
 		}
 		cleanedName := filepath.Clean(hdr.Name)
+		if cleanedName == "." && config.EnvBool("FF_KANIKO_UNTAR_SKIP_ROOT") {
+			continue
+		}
 		if err := ExtractFile(dest, hdr, cleanedName, tr); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes #841

When `ADD` extracts a local tar archive into a directory, kaniko applied the archive's root `.` entry to the destination directory and overwrote its mode and ownership, while docker leaves the destination untouched. Behind `FF_KANIKO_UNTAR_SKIP_ROOT` the `.` entry is skipped when untarring so the destination keeps its own mode and ownership. The flag defaults to off and becomes default in v1.29.0.

With the flag enabled in the integration suite this also lets `Dockerfile_test_add` drop its `--extra-ignore-file-permissions` diffoci exception, which existed only to mask this behavior.
