### PR TITLE
stop ignoring layer-length mismatch in integration tests

### DIFF
--- a/integration/config.go
+++ b/integration/config.go
@@ -26,6 +26,7 @@ type integrationTestConfig struct {
 	gcsBucket               string
 	imageRepo               string
 	busyboxBaseImage        string
+	alpineBaseImage         string
 	onbuildBaseImage        string
 	onbuildCopyImage        string
 	hardlinkBaseImage       string

--- a/integration/config.go
+++ b/integration/config.go
@@ -25,6 +25,7 @@ import (
 type integrationTestConfig struct {
 	gcsBucket               string
 	imageRepo               string
+	busyboxBaseImage        string
 	onbuildBaseImage        string
 	onbuildCopyImage        string
 	hardlinkBaseImage       string

--- a/integration/dockerfiles/Dockerfile_alpine_base
+++ b/integration/dockerfiles/Dockerfile_alpine_base
@@ -1,0 +1,6 @@
+FROM alpine
+# alpine ships without /proc and /sys. buildkit creates them as mountpoints on the
+# first RUN and commits the empty dirs into that layer, while kaniko ignores them as
+# they are mounts in its own environment. Baking them into the base means buildkit has
+# nothing new to commit, so both builders agree.
+RUN mkdir -p /proc /sys

--- a/integration/dockerfiles/Dockerfile_busybox_base
+++ b/integration/dockerfiles/Dockerfile_busybox_base
@@ -1,0 +1,6 @@
+FROM busybox
+# busybox ships without /proc and /sys. buildkit creates them as mountpoints on
+# the first RUN and commits the empty dirs into that layer, while kaniko ignores
+# them as they are mounts in its own environment. Baking them into the base means
+# buildkit has nothing new to commit, so both builders agree.
+RUN mkdir -p /proc /sys

--- a/integration/dockerfiles/Dockerfile_test_arg_blank_with_quotes
+++ b/integration/dockerfiles/Dockerfile_test_arg_blank_with_quotes
@@ -1,11 +1,12 @@
+ARG IMAGE_REPO
 ARG FILE_NAME=""
 
-FROM busybox:latest AS builder
+FROM ${IMAGE_REPO}busybox AS builder
 ARG FILE_NAME
 
 RUN echo $FILE_NAME && touch /$FILE_NAME.txt && stat /$FILE_NAME.txt;
 
-FROM busybox:latest
+FROM ${IMAGE_REPO}busybox
 ARG FILE_NAME
 
 RUN echo $FILE_NAME && touch /$FILE_NAME.txt && stat /$FILE_NAME.txt;

--- a/integration/dockerfiles/Dockerfile_test_arg_multi
+++ b/integration/dockerfiles/Dockerfile_test_arg_multi
@@ -1,11 +1,12 @@
+ARG IMAGE_REPO
 ARG FILE_NAME=myFile
 
-FROM busybox:latest AS builder
+FROM ${IMAGE_REPO}busybox AS builder
 ARG FILE_NAME
 
 RUN echo $FILE_NAME && touch /$FILE_NAME.txt && stat /$FILE_NAME.txt;
 
-FROM busybox:latest
+FROM ${IMAGE_REPO}busybox
 ARG FILE_NAME
 
 RUN echo $FILE_NAME && touch /$FILE_NAME.txt && stat /$FILE_NAME.txt;

--- a/integration/dockerfiles/Dockerfile_test_arg_multi_with_quotes
+++ b/integration/dockerfiles/Dockerfile_test_arg_multi_with_quotes
@@ -1,11 +1,12 @@
+ARG IMAGE_REPO
 ARG FILE_NAME="myFile"
 
-FROM busybox:latest AS builder
+FROM ${IMAGE_REPO}busybox AS builder
 ARG FILE_NAME
 
 RUN echo $FILE_NAME && touch /$FILE_NAME.txt && stat /$FILE_NAME.txt;
 
-FROM busybox:latest
+FROM ${IMAGE_REPO}busybox
 ARG FILE_NAME
 
 RUN echo $FILE_NAME && touch /$FILE_NAME.txt && stat /$FILE_NAME.txt;

--- a/integration/dockerfiles/Dockerfile_test_cache_perm_oci
+++ b/integration/dockerfiles/Dockerfile_test_cache_perm_oci
@@ -1,8 +1,9 @@
+ARG IMAGE_REPO
 # Test to make sure the cache works with special file permissions properly.
 # If the image is built twice, directory foo should have the sticky bit,
 # and file bar should have the setuid and setgid bits.
 
-FROM busybox
+FROM ${IMAGE_REPO}busybox
 
 RUN mkdir foo && chmod +t foo
 RUN touch bar && chmod u+s,g+s bar

--- a/integration/dockerfiles/Dockerfile_test_complex_substitution
+++ b/integration/dockerfiles/Dockerfile_test_complex_substitution
@@ -1,2 +1,3 @@
-FROM docker.io/library/busybox:latest@sha256:afe605d272837ce1732f390966166c2afff5391208ddd57de10942748694049d
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
 RUN echo ${s%s}

--- a/integration/dockerfiles/Dockerfile_test_copy_same_file_many_times
+++ b/integration/dockerfiles/Dockerfile_test_copy_same_file_many_times
@@ -1,4 +1,5 @@
-FROM alpine@sha256:5ce5f501c457015c4b91f91a15ac69157d9b06f1a75cf9107bf2b62e0843983a
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}alpine
 COPY context/foo /foo
 COPY context/foo /foo
 COPY context/foo /foo

--- a/integration/dockerfiles/Dockerfile_test_daemons
+++ b/integration/dockerfiles/Dockerfile_test_daemons
@@ -1,3 +1,4 @@
-FROM busybox
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
 RUN (while true; do sleep 10; dd if=/dev/zero of=file`date +%s`.txt count=16000 bs=256  > /dev/null 2>&1; done &); sleep 1
 RUN echo "wait a second..." && sleep 2 && ls -lrat file*.txt || echo "test passed."

--- a/integration/dockerfiles/Dockerfile_test_dangling_symlink
+++ b/integration/dockerfiles/Dockerfile_test_dangling_symlink
@@ -1,2 +1,3 @@
-FROM busybox:latest@sha256:b26cd013274a657b86e706210ddd5cc1f82f50155791199d29b9e86e935ce135
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
 RUN ["/bin/ln", "-s", "nowhere", "/link"]

--- a/integration/dockerfiles/Dockerfile_test_issue_1007
+++ b/integration/dockerfiles/Dockerfile_test_issue_1007
@@ -1,4 +1,5 @@
-FROM alpine AS build
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}alpine AS build
 
 RUN apk add --no-scripts --initdb \
   --keys-dir /etc/apk/keys \

--- a/integration/dockerfiles/Dockerfile_test_issue_1568
+++ b/integration/dockerfiles/Dockerfile_test_issue_1568
@@ -1,4 +1,5 @@
-FROM busybox
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
 
 # we can mount a directory from context to a target as specificed
 RUN --mount=type=bind,source=context,rw,target=/tmp/bli/bla/ \

--- a/integration/dockerfiles/Dockerfile_test_issue_1713
+++ b/integration/dockerfiles/Dockerfile_test_issue_1713
@@ -1,4 +1,5 @@
-FROM busybox
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
 RUN <<EOF
 touch /tmp/bli
 touch /tmp/bla

--- a/integration/dockerfiles/Dockerfile_test_issue_3224
+++ b/integration/dockerfiles/Dockerfile_test_issue_3224
@@ -1,4 +1,5 @@
-FROM busybox
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
 
 # 3224: Spawn a short-lived child
 # then check if it became a zombie

--- a/integration/dockerfiles/Dockerfile_test_issue_969
+++ b/integration/dockerfiles/Dockerfile_test_issue_969
@@ -1,4 +1,5 @@
-FROM busybox
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
 
 # we can mount a cache directory to a target as specificed
 RUN --mount=type=cache,target=/tmp/bli/bla/ \

--- a/integration/dockerfiles/Dockerfile_test_issue_cg188
+++ b/integration/dockerfiles/Dockerfile_test_issue_cg188
@@ -1,4 +1,5 @@
-FROM busybox AS first
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox AS first
 
 # we can mount a secret to a target file
 RUN --mount=type=secret,id=netrc \

--- a/integration/dockerfiles/Dockerfile_test_issue_cg326_2
+++ b/integration/dockerfiles/Dockerfile_test_issue_cg326_2
@@ -1,4 +1,5 @@
-FROM busybox
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
 
 # Attack 2: symlink path traversal.
 # A malicious upstream image can escape the dependency dir via a symlink even

--- a/integration/dockerfiles/Dockerfile_test_issue_cg326_3
+++ b/integration/dockerfiles/Dockerfile_test_issue_cg326_3
@@ -1,4 +1,5 @@
-FROM busybox
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
 
 # Regression flagged against the cg326 symlink-target check.
 # Some base images ship a symlink with more ".." than its depth. Real example,

--- a/integration/dockerfiles/Dockerfile_test_issue_mz247
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz247
@@ -1,4 +1,5 @@
-FROM busybox AS base
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox AS base
 
 # mz247: Starting with v1.25.3 we introduced a regression
 # in this PR https://github.com/mzihlmann/kaniko/pull/180

--- a/integration/dockerfiles/Dockerfile_test_issue_mz276
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz276
@@ -1,4 +1,5 @@
-FROM busybox AS first
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox AS first
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/integration/dockerfiles/Dockerfile_test_issue_mz305
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz305
@@ -1,7 +1,8 @@
-FROM busybox AS zero
-FROM busybox AS one
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox AS zero
+FROM ${IMAGE_REPO}busybox AS one
 RUN touch /tmp/blubb
-FROM busybox AS two
+FROM ${IMAGE_REPO}busybox AS two
 # mz305: build fails in kaniko v1.25.6 and priors.
 # --skip-unused-stages can drop stages, and we refer to them by the list index in code.
 # However, in the commands themselves the indizes are never updated.

--- a/integration/dockerfiles/Dockerfile_test_issue_mz332
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz332
@@ -1,5 +1,5 @@
 ARG IMAGE_REPO
-FROM busybox:latest AS base
+FROM ${IMAGE_REPO}busybox AS base
 RUN touch /blubb
 
 FROM doesnt:exist

--- a/integration/dockerfiles/Dockerfile_test_issue_mz444
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz444
@@ -1,3 +1,4 @@
+ARG IMAGE_REPO
 # mz444: Kaniko always supported the KANIKO_DIR environment variable,
 # which can be used to relocate kaniko folder after boot.
 # This is useful for bootstrapping kaniko itself. However, kaniko v1.26.4
@@ -11,5 +12,5 @@ ENV SSL_CERT_DIR=/opt/kaniko/ssl/certs
 ENTRYPOINT ["/opt/kaniko/executor"]
 
 # And then verify that if we build with this executor the /kaniko dir is indeed empty
-FROM busybox:latest
+FROM ${IMAGE_REPO}busybox
 RUN [ ! -d /kaniko ]

--- a/integration/dockerfiles/Dockerfile_test_issue_mz455
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz455
@@ -1,3 +1,4 @@
+ARG IMAGE_REPO
 # mz455: In kaniko v1.26.4, cache mounts used rename() to swap cache directories in and out.
 # This fails if the directories have to be moved across filesystems.
 # Since kaniko's FROM, COPY, and other commands do not create new overlay filesystems,
@@ -11,7 +12,7 @@ FROM executor-image AS kaniko
 WORKDIR /var/lib/apt/list/blubb
 WORKDIR /
 
-FROM busybox:latest
+FROM ${IMAGE_REPO}busybox
 
 # In kaniko v1.26.4, this now fails because rename() cannot move directories across filesystems.
 RUN --mount=type=cache,target=/var/lib/apt/list \

--- a/integration/dockerfiles/Dockerfile_test_issue_mz473
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz473
@@ -1,4 +1,5 @@
-FROM busybox:latest
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
 
 # mz473: in kaniko v1.26.4, due to a regression in our CopyDir,
 # When running kaniko with KANIKO_DIR=/kaniko2 in order to relocate the binary,

--- a/integration/dockerfiles/Dockerfile_test_issue_mz511
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz511
@@ -1,4 +1,5 @@
-FROM busybox AS first
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox AS first
 
 # we can mount a secret to a target file
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \

--- a/integration/dockerfiles/Dockerfile_test_issue_mz529
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz529
@@ -1,9 +1,10 @@
+ARG IMAGE_REPO
 # mz529: in kaniko v1.26.5 kaniko learned to cleanup the
 # kaniko-dir after build. This was done because if a script tries
 # to retry the build, having leftovers in kaniko-dir leads to failed builds.
 # However, the kaniko-dir was cleaned after build, but before push.
 # So now regular builds that simply try to run through once failed.
-FROM busybox AS base
+FROM ${IMAGE_REPO}busybox AS base
 
 RUN touch test
 FROM base AS nosquash

--- a/integration/dockerfiles/Dockerfile_test_issue_mz560
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz560
@@ -6,7 +6,7 @@
 # This sounds bad, but is actually by design. It is not less secure than having an `ONBUILD` per-se.
 # Docker build is RCE as a service, that is the reason why kaniko does run without privileges.
 ARG IMAGE_REPO
-FROM busybox AS base
+FROM ${IMAGE_REPO}busybox AS base
 # We simulate command injection by hijacking the tini binary
 
 # First we hijack it by adding a hijacked binary to this base image.

--- a/integration/dockerfiles/Dockerfile_test_issue_mz621
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz621
@@ -1,8 +1,9 @@
+ARG IMAGE_REPO
 # mz621: --single-snapshot with a metadata-only final command (LABEL) after a
 # filesystem-modifying command (RUN) must not panic.
 # In single-snapshot mode TakeSnapshotFS accumulates all build changes; the
 # "MetadataOnly command snapshotted N files" assertion must be gated on
 # !opts.SingleSnapshot.
-FROM busybox
+FROM ${IMAGE_REPO}busybox
 RUN touch /x
 LABEL a=b

--- a/integration/dockerfiles/Dockerfile_test_issue_mz622
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz622
@@ -1,24 +1,25 @@
+ARG IMAGE_REPO
 # mz622: present in kaniko v1.27.2.
 # ARG values leak across sibling stages.
-FROM busybox AS base1
+FROM ${IMAGE_REPO}busybox AS base1
 ARG ARG1=blubb
 RUN echo "$ARG1 $ARG2" > out1
 
 # base2 never declares ARG1. out2 should contain " bla"
 # but kaniko produces "blubb bla", indicating the previous ARG leaked.
-FROM busybox AS base2
+FROM ${IMAGE_REPO}busybox AS base2
 ARG ARG2=bla
 RUN echo "$ARG1 $ARG2" > out2
 
 # base3 defines a new default value for ARG1,
 # This shouldn't interfere with what base1 defined.
-FROM busybox AS base3
+FROM ${IMAGE_REPO}busybox AS base3
 ARG ARG1=bli
 RUN echo "$ARG1 $ARG2" > out3
 FROM base1 AS base4
 RUN echo "$ARG1 $ARG2" > out4
 
-FROM busybox
+FROM ${IMAGE_REPO}busybox
 COPY --from=base1 out1 out1
 COPY --from=base2 out2 out2
 COPY --from=base3 out3 out3

--- a/integration/dockerfiles/Dockerfile_test_issue_mz661
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz661
@@ -1,3 +1,4 @@
+ARG IMAGE_REPO
 # mz661: in kaniko v1.27.3, when running with KANIKO_DIR=/kaniko2 to relocate the
 # executor, moveKanikoDir runs before resolveSecrets. A --secret with src= pointing
 # into the original kaniko dir (e.g. src=/kaniko/.netrc) is moved away before the
@@ -6,5 +7,5 @@
 # /kaniko/executor is used as the secret source here only because it is a file that
 # already exists in the container, standing in for any real credential file.
 # Verify here that the secret is accessible inside the build.
-FROM busybox
+FROM ${IMAGE_REPO}busybox
 RUN --mount=type=secret,id=kaniko test -s /run/secrets/kaniko

--- a/integration/dockerfiles/Dockerfile_test_issue_mz725
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz725
@@ -5,7 +5,7 @@ ARG IMAGE_REPO
 # WorkingDir, User=root) and pushes back to the same tag. The result is a
 # malformed-but-valid image — unproducible by docker/podman/buildah but
 # reachable from any hand-crafted OCI producer.
-FROM busybox AS base
+FROM ${IMAGE_REPO}busybox AS base
 RUN echo 'single' >> /etc/group
 
 FROM ${IMAGE_REPO}malformed-oci:latest

--- a/integration/dockerfiles/Dockerfile_test_issue_mz789
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz789
@@ -1,3 +1,4 @@
+ARG IMAGE_REPO
 # mz789: the cache-lookahead precompute crashes on a stage whose local base
 # cannot be keyed. Panics on v1.27.6 with FF_KANIKO_CACHE_LOOKAHEAD enabled.
 # base has a COPY --from, so the precompute cannot key it. The final stage is
@@ -6,10 +7,10 @@
 # hash of an empty composite as the final stage's key. The build computes a real
 # key from base's built digest, the two disagree, and the executor panics on the
 # executor.build.cache-lookahead assertion.
-FROM busybox AS src
+FROM ${IMAGE_REPO}busybox AS src
 RUN echo x > /x
 
-FROM busybox AS base
+FROM ${IMAGE_REPO}busybox AS base
 COPY --from=src /x /x
 FROM base AS nosquash
 

--- a/integration/dockerfiles/Dockerfile_test_mv_add
+++ b/integration/dockerfiles/Dockerfile_test_mv_add
@@ -1,4 +1,5 @@
-FROM busybox@sha256:1bd6df27274fef1dd36eb529d0f4c8033f61c675d6b04213dd913f902f7cafb5
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
 ADD context/tars /tmp/tars
 RUN stat /bin/sh
 RUN mv /tmp/tars /foo

--- a/integration/dockerfiles/Dockerfile_test_parent_dir_perms
+++ b/integration/dockerfiles/Dockerfile_test_parent_dir_perms
@@ -1,4 +1,5 @@
-FROM busybox
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
 
 RUN adduser --disabled-password --gecos "" --uid 1000 user
 RUN mkdir -p /home/user/foo

--- a/integration/dockerfiles/Dockerfile_test_registry
+++ b/integration/dockerfiles/Dockerfile_test_registry
@@ -1,2 +1,3 @@
-FROM busybox@sha256:1bd6df27274fef1dd36eb529d0f4c8033f61c675d6b04213dd913f902f7cafb5
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
 RUN echo "hey" > /hey

--- a/integration/images.go
+++ b/integration/images.go
@@ -125,14 +125,12 @@ var additionalDockerFlagsMap = map[string][]string{
 	"Dockerfile_test_issue_mz661": {"--secret=id=kaniko,src=context/foo"},
 	// provenance forces ociv1 on buildkit but for these images we emit dockerv2 in kaniko
 	"Dockerfile_test_cross_compile":                {"--platform=linux/" + crossCompileArch},
-	"Dockerfile_test_mv_add":                       {"--provenance=false"},
 	"Dockerfile_test_snapshotter_ignorelist":       {"--provenance=false"},
 	"Dockerfile_test_whitelist":                    {"--provenance=false"},
 	"Dockerfile_test_volume_4":                     {"--provenance=false"},
 	"Dockerfile_test_volume_3":                     {"--provenance=false"},
 	"Dockerfile_test_meta_arg":                     {"--provenance=false"},
 	"Dockerfile_test_replaced_symlinks":            {"--provenance=false"},
-	"Dockerfile_test_registry":                     {"--provenance=false"},
 	"Dockerfile_test_pre_defined_build_args":       {"--provenance=false"},
 	"Dockerfile_test_replaced_hardlinks":           {"--provenance=false"},
 	"Dockerfile_test_issue_647":                    {"--provenance=false"},
@@ -140,14 +138,11 @@ var additionalDockerFlagsMap = map[string][]string{
 	"Dockerfile_test_issue_1837":                   {"--provenance=false"},
 	"Dockerfile_test_issue_2049":                   {"--provenance=false"},
 	"Dockerfile_test_issue_1039":                   {"--provenance=false"},
-	"Dockerfile_test_dangling_symlink":             {"--provenance=false"},
 	"Dockerfile_test_copyadd_chmod":                {"--provenance=false"},
-	"Dockerfile_test_copy_same_file_many_times":    {"--provenance=false"},
 	"Dockerfile_test_copy_reproducible":            {"--provenance=false"},
 	"Dockerfile_test_copy_chown_intermediate_dirs": {"--provenance=false"},
 	"Dockerfile_test_copy":                         {"--provenance=false"},
 	"Dockerfile_test_copy_bucket":                  {"--provenance=false"},
-	"Dockerfile_test_complex_substitution":         {"--provenance=false"},
 	"Dockerfile_test_cache_copy_oci":               {"--provenance=false"},
 	"Dockerfile_test_add_url_with_arg":             {"--provenance=false"},
 	"Dockerfile_test_add_dest_symlink_dir":         {"--provenance=false"},
@@ -266,21 +261,14 @@ var diffArgsMap = map[string][]string{
 	// each build, so its mtime differs between the two cached builds. That divergence is the
 	// known volume non-determinism the flag fixes, here we only assert the build no longer panics.
 	"TestCache/test_cache_Dockerfile_test_issue_mz793": {"--extra-ignore-files=data/"},
-	// Layer-length divergences from buildkit, enforced per-test instead of globally so new
-	// tests still catch regressions. These are pre-existing kaniko layer-composition
-	// differences (no COPY dedup, ignorelisted paths in ADDed tars, ONBUILD base re-emission,
-	// empty package-manager dirs); reasons are pinned per-test from local diffoci runs.
+	// Layer-length divergences from buildkit, enforced per-test instead of globally
 	"TestRun/test_Dockerfile_test_add":                       {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_arg_blank_with_quotes":     {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_arg_multi":                 {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_arg_multi_with_quotes":     {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_cache_install_oci":         {"--extra-ignore-layer-length-mismatch"},
-	"TestRun/test_Dockerfile_test_complex_substitution":      {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_copy_same_file_many_times": {"--extra-ignore-layer-length-mismatch"},
-	"TestRun/test_Dockerfile_test_dangling_symlink":          {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_meta_arg":                  {"--extra-ignore-layer-length-mismatch"},
-	"TestRun/test_Dockerfile_test_mv_add":                    {"--extra-ignore-layer-length-mismatch"},
-	"TestRun/test_Dockerfile_test_registry":                  {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_scratch":                   {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_issue_969":                 {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_issue_1007":                {"--extra-ignore-layer-length-mismatch"},

--- a/integration/images.go
+++ b/integration/images.go
@@ -237,10 +237,10 @@ var diffArgsMap = map[string][]string{
 	// /root/.config 0x1c0 0x1ed
 	// I suspect the issue is that /root/.config pre-exists,
 	// it's where we store the docker credentials.
-	"TestWithContext/test_with_context_issue-1020": {"--extra-ignore-files=root/.config/"},
+	"TestWithContext/test_with_context_issue-1020": {"--extra-ignore-files=root/.config/", "--extra-ignore-layer-length-mismatch"},
 	// docker is wrong. we do copy the symlink correctly.
-	"TestRun/test_Dockerfile_test_copy_symlink": {"--extra-ignore-files=workdirAnother/relative_link"},
-	"TestRun/test_Dockerfile_test_multistage":   {"--extra-ignore-files=new"},
+	"TestRun/test_Dockerfile_test_copy_symlink":  {"--extra-ignore-files=workdirAnother/relative_link"},
+	"TestRun/test_Dockerfile_test_multistage":    {"--extra-ignore-files=new", "--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_cross_compile": {"--platform=linux/" + crossCompileArch},
 	// kaniko adds parent directories of changed paths to the full-filesystem snapshot
 	"TestRun/test_Dockerfile_test_volume":   {"--extra-ignore-layer-length-mismatch"},
@@ -261,11 +261,47 @@ var diffArgsMap = map[string][]string{
 	// mz511: We delete the builtin file /etc/nsswitch.conf to verify that secrets are persisted
 	// But we discovered a new issue with this. For builtins, buildkit will emit "whiteout" files,
 	// to remember that it was removed, we don't. So we end up with a diff in the resulting image.
-	"TestRun/test_Dockerfile_test_issue_mz511": {"--extra-ignore-files=etc/.wh.nsswitch.conf"},
+	"TestRun/test_Dockerfile_test_issue_mz511": {"--extra-ignore-files=etc/.wh.nsswitch.conf", "--extra-ignore-layer-length-mismatch"},
 	// mz793: with FF_KANIKO_VOLUME_SKIP_MKDIR off, VOLUME creates the directory fresh on
 	// each build, so its mtime differs between the two cached builds. That divergence is the
 	// known volume non-determinism the flag fixes, here we only assert the build no longer panics.
 	"TestCache/test_cache_Dockerfile_test_issue_mz793": {"--extra-ignore-files=data/"},
+	// Layer-length divergences from buildkit, enforced per-test instead of globally so new
+	// tests still catch regressions. These are pre-existing kaniko layer-composition
+	// differences (no COPY dedup, ignorelisted paths in ADDed tars, ONBUILD base re-emission,
+	// empty package-manager dirs); reasons are pinned per-test from local diffoci runs.
+	"TestRun/test_Dockerfile_test_add":                       {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_arg_blank_with_quotes":     {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_arg_multi":                 {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_arg_multi_with_quotes":     {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_cache_install_oci":         {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_complex_substitution":      {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_copy_same_file_many_times": {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_dangling_symlink":          {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_meta_arg":                  {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_mv_add":                    {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_registry":                  {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_scratch":                   {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_969":                 {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_1007":                {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_1039":                {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_1568":                {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_1837":                {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_2049":                {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_2066":                {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_3393":                {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_cg73":                {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_cg188":               {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_mz247":               {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_mz332":               {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_mz455":               {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_mz560":               {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_issue_mz725":               {"--extra-ignore-layer-length-mismatch"},
+	"TestWithContext/test_with_context_issue-57":             {"--extra-ignore-layer-length-mismatch"},
+	"TestWithContext/test_with_context_issue-1568":           {"--extra-ignore-layer-length-mismatch"},
+	"TestK8s/test_k8s_with_context_issue-57":                 {"--extra-ignore-layer-length-mismatch"},
+	"TestK8s/test_k8s_with_context_issue-1020":               {"--extra-ignore-layer-length-mismatch"},
+	"TestK8s/test_k8s_with_context_issue-1568":               {"--extra-ignore-layer-length-mismatch"},
 }
 
 // output check to do when building with kaniko

--- a/integration/images.go
+++ b/integration/images.go
@@ -242,6 +242,9 @@ var diffArgsMap = map[string][]string{
 	"TestRun/test_Dockerfile_test_copy_symlink": {"--extra-ignore-files=workdirAnother/relative_link"},
 	"TestRun/test_Dockerfile_test_multistage":   {"--extra-ignore-files=new"},
 	"TestRun/test_Dockerfile_test_cross_compile": {"--platform=linux/" + crossCompileArch},
+	// kaniko adds parent directories of changed paths to the full-filesystem snapshot
+	"TestRun/test_Dockerfile_test_volume":   {"--extra-ignore-layer-length-mismatch"},
+	"TestRun/test_Dockerfile_test_volume_2": {"--extra-ignore-layer-length-mismatch"},
 	// FROM scratch we start with root, buildkit doesnt
 	"TestRun/test_Dockerfile_test_workdir_with_user": {"--extra-ignore-file-permissions"},
 	// We don't handle user nobody=-1 nogroup=-1 correctly

--- a/integration/images.go
+++ b/integration/images.go
@@ -241,11 +241,7 @@ var diffArgsMap = map[string][]string{
 	// docker is wrong. we do copy the symlink correctly.
 	"TestRun/test_Dockerfile_test_copy_symlink": {"--extra-ignore-files=workdirAnother/relative_link"},
 	"TestRun/test_Dockerfile_test_multistage":   {"--extra-ignore-files=new"},
-	// Verify we don't store root directory
-	"TestRun/test_Dockerfile_test_root":          {"--extra-ignore-layer-length-mismatch=false"},
 	"TestRun/test_Dockerfile_test_cross_compile": {"--platform=linux/" + crossCompileArch},
-	// --ignore-path must suppress the kaniko-only file; layer-length-mismatch would mask the difference
-	"TestRun/test_Dockerfile_test_ignore_path": {"--extra-ignore-layer-length-mismatch=false"},
 	// FROM scratch we start with root, buildkit doesnt
 	"TestRun/test_Dockerfile_test_workdir_with_user": {"--extra-ignore-file-permissions"},
 	// We don't handle user nobody=-1 nogroup=-1 correctly
@@ -263,9 +259,6 @@ var diffArgsMap = map[string][]string{
 	// But we discovered a new issue with this. For builtins, buildkit will emit "whiteout" files,
 	// to remember that it was removed, we don't. So we end up with a diff in the resulting image.
 	"TestRun/test_Dockerfile_test_issue_mz511": {"--extra-ignore-files=etc/.wh.nsswitch.conf"},
-	// mz595: surprisingly the missing files are **not** picked up if we ignore layer-length-mismatch,
-	// which we do by default in TestRun, we should move to disable that globally urgently.
-	"TestRun/test_Dockerfile_test_issue_mz595": {"--extra-ignore-layer-length-mismatch=false"},
 	// mz793: with FF_KANIKO_VOLUME_SKIP_MKDIR off, VOLUME creates the directory fresh on
 	// each build, so its mtime differs between the two cached builds. That divergence is the
 	// known volume non-determinism the flag fixes, here we only assert the build no longer panics.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -158,6 +158,9 @@ func buildRequiredImages() error {
 		name:    "Building busybox base image",
 		command: []string{"docker", "build", "--push", "-t", config.busyboxBaseImage, "-f", dockerfilesPath + "/Dockerfile_busybox_base", "."},
 	}, {
+		name:    "Building alpine base image",
+		command: []string{"docker", "build", "--push", "-t", config.alpineBaseImage, "-f", dockerfilesPath + "/Dockerfile_alpine_base", "."},
+	}, {
 		name:    "Building onbuild base image",
 		command: []string{"docker", "build", "--push", "-t", config.onbuildBaseImage, "-f", dockerfilesPath + "/Dockerfile_onbuild_base", "."},
 	}, {
@@ -1595,6 +1598,7 @@ func initIntegrationTestConfig() *integrationTestConfig {
 
 	c.dockerMajorVersion = getDockerMajorVersion()
 	c.busyboxBaseImage = c.imageRepo + "busybox:latest"
+	c.alpineBaseImage = c.imageRepo + "alpine:latest"
 	c.onbuildBaseImage = c.imageRepo + "onbuild-base:latest"
 	c.onbuildCopyImage = c.imageRepo + "onbuild-copy:latest"
 	c.hardlinkBaseImage = c.imageRepo + "hardlink-base:latest"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -155,6 +155,9 @@ func buildRequiredImages() error {
 		name:    "Building cache warmer image",
 		command: []string{"docker", "build", coverArg, "-t", WarmerImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-warmer", ".."},
 	}, {
+		name:    "Building busybox base image",
+		command: []string{"docker", "build", "--push", "-t", config.busyboxBaseImage, "-f", dockerfilesPath + "/Dockerfile_busybox_base", "."},
+	}, {
 		name:    "Building onbuild base image",
 		command: []string{"docker", "build", "--push", "-t", config.onbuildBaseImage, "-f", dockerfilesPath + "/Dockerfile_onbuild_base", "."},
 	}, {
@@ -1591,6 +1594,7 @@ func initIntegrationTestConfig() *integrationTestConfig {
 	}
 
 	c.dockerMajorVersion = getDockerMajorVersion()
+	c.busyboxBaseImage = c.imageRepo + "busybox:latest"
 	c.onbuildBaseImage = c.imageRepo + "onbuild-base:latest"
 	c.onbuildCopyImage = c.imageRepo + "onbuild-copy:latest"
 	c.hardlinkBaseImage = c.imageRepo + "hardlink-base:latest"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -244,7 +244,7 @@ func TestRun(t *testing.T) {
 			dockerImage := GetDockerImage(config.imageRepo, dockerfile)
 			kanikoImage := GetKanikoImage(config.imageRepo, dockerfile)
 
-			containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
+			containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content")
 		})
 	}
 
@@ -354,7 +354,7 @@ func testGitBuildcontextHelper(t *testing.T, url string, commit string, branch s
 		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
 	}
 
-	containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
+	containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content")
 }
 
 // TestGitBuildcontext explicitly names the main branch
@@ -429,7 +429,7 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
 	}
 
-	containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
+	containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content")
 }
 
 func TestBuildViaRegistryMirrors(t *testing.T) {
@@ -471,7 +471,7 @@ func TestBuildViaRegistryMirrors(t *testing.T) {
 		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
 	}
 
-	containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
+	containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content")
 }
 
 func TestBuildViaRegistryMap(t *testing.T) {
@@ -513,7 +513,7 @@ func TestBuildViaRegistryMap(t *testing.T) {
 		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
 	}
 
-	containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
+	containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content")
 }
 
 func TestBuildSkipFallback(t *testing.T) {
@@ -580,7 +580,7 @@ func TestKanikoDir(t *testing.T) {
 		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
 	}
 
-	containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
+	containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content")
 }
 
 func TestBuildWithLabels(t *testing.T) {
@@ -625,7 +625,7 @@ func TestBuildWithLabels(t *testing.T) {
 		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
 	}
 
-	containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
+	containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content")
 }
 
 func TestBuildWithHTTPError(t *testing.T) {
@@ -1203,7 +1203,7 @@ func TestRelativePaths(t *testing.T) {
 		dockerImage := GetDockerImage(config.imageRepo, "test_relative_"+dockerfile)
 		kanikoImage := GetKanikoImage(config.imageRepo, "test_relative_"+dockerfile)
 
-		containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
+		containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content")
 	})
 }
 

--- a/integration/integration_with_context_test.go
+++ b/integration/integration_with_context_test.go
@@ -63,7 +63,7 @@ func TestWithContext(t *testing.T) {
 			dockerImage := GetDockerImage(config.imageRepo, name)
 			kanikoImage := GetKanikoImage(config.imageRepo, name)
 
-			containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
+			containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content")
 		})
 	}
 

--- a/integration/integration_with_stdin_test.go
+++ b/integration/integration_with_stdin_test.go
@@ -141,7 +141,7 @@ func TestBuildWithStdin(t *testing.T) {
 		t.Fatalf("can't wait %s: %v", kanikoCmdStdin.String(), err)
 	}
 
-	containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
+	containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content")
 
 	if err := os.RemoveAll(testDirLongPath); err != nil {
 		t.Errorf("Failed to remove %s: %v", testDirLongPath, err)

--- a/integration/k8s_test.go
+++ b/integration/k8s_test.go
@@ -130,7 +130,7 @@ func TestK8s(t *testing.T) {
 				t.Fatal(errR)
 			}
 
-			containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content", "--extra-ignore-layer-length-mismatch")
+			containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content")
 		})
 	}
 

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -200,19 +200,15 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 	timer := timing.Start("Resolving Paths")
 
 	filesToAdd := []string{}
-	resolvedFiles, err := filesystem.ResolvePaths(changedPaths, s.ignorelist)
-	if err != nil {
-		return nil, nil, err
-	}
-	for _, path := range resolvedFiles {
-		if util.CheckIgnoreList(path) {
+	for _, path := range changedPaths {
+		if util.IsInProvidedIgnoreList(path, s.ignorelist) {
 			logrus.Debugf("Not adding %s to layer, as it's ignored", path)
 			continue
 		}
 		filesToAdd = append(filesToAdd, path)
 	}
 	// Ignore-list filtering can only reduce the file set.
-	util.Assert("snapshot.scan.files-count", len(filesToAdd) <= len(resolvedFiles), "scanFullFilesystem: filesToAdd (%d) exceeds resolvedFiles (%d)", len(resolvedFiles), len(filesToAdd))
+	util.Assert("snapshot.scan.files-count", len(filesToAdd) <= len(changedPaths), "scanFullFilesystem: filesToAdd (%d) exceeds changedPaths (%d)", len(changedPaths), len(filesToAdd))
 
 	logrus.Debugf("Adding to layer: %v", filesToAdd)
 	logrus.Debugf("Deleting in layer: %v", deletedPaths)

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -200,15 +200,19 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 	timer := timing.Start("Resolving Paths")
 
 	filesToAdd := []string{}
-	for _, path := range changedPaths {
-		if util.IsInProvidedIgnoreList(path, s.ignorelist) {
+	resolvedFiles, err := filesystem.ResolvePaths(changedPaths, s.ignorelist)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, path := range resolvedFiles {
+		if util.CheckIgnoreList(path) {
 			logrus.Debugf("Not adding %s to layer, as it's ignored", path)
 			continue
 		}
 		filesToAdd = append(filesToAdd, path)
 	}
 	// Ignore-list filtering can only reduce the file set.
-	util.Assert("snapshot.scan.files-count", len(filesToAdd) <= len(changedPaths), "scanFullFilesystem: filesToAdd (%d) exceeds changedPaths (%d)", len(changedPaths), len(filesToAdd))
+	util.Assert("snapshot.scan.files-count", len(filesToAdd) <= len(resolvedFiles), "scanFullFilesystem: filesToAdd (%d) exceeds resolvedFiles (%d)", len(resolvedFiles), len(filesToAdd))
 
 	logrus.Debugf("Adding to layer: %v", filesToAdd)
 	logrus.Debugf("Deleting in layer: %v", deletedPaths)

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -221,6 +221,7 @@ func TestSnapshotFSReplaceDirWithLink(t *testing.T) {
 	testDirWithoutLeadingSlash := strings.TrimLeft(testDir, "/")
 	expectedFiles := []string{
 		filepath.Join(testDirWithoutLeadingSlash, "bar"),
+		filepath.Join(testDirWithoutLeadingSlash, "foo"),
 	}
 	for _, path := range parentDirectoriesWithoutLeadingSlash(filepath.Join(testDir, "foo")) {
 		if path == config.RootDir {

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -221,7 +221,6 @@ func TestSnapshotFSReplaceDirWithLink(t *testing.T) {
 	testDirWithoutLeadingSlash := strings.TrimLeft(testDir, "/")
 	expectedFiles := []string{
 		filepath.Join(testDirWithoutLeadingSlash, "bar"),
-		filepath.Join(testDirWithoutLeadingSlash, "foo"),
 	}
 	for _, path := range parentDirectoriesWithoutLeadingSlash(filepath.Join(testDir, "foo")) {
 		if path == config.RootDir {


### PR DESCRIPTION
Stop passing `--extra-ignore-layer-length-mismatch` to diffoci globally and enforce layer-length parity by default, so divergences are caught instead of hidden.

Minimal bases (busybox/alpine/scratch) lack `/proc` and `/sys`, which BuildKit commits on the first RUN but kaniko ignores as mounts, so those tests now build from a prepared `${IMAGE_REPO}busybox`/`alpine` base that bakes the dirs in.

Genuine kaniko divergences from BuildKit (no COPY dedup, ignorelisted tar paths, ONBUILD base re-emission, empty package-manager dirs) keep an explicit per-test exception, to be fixed separately.

The four tests pinning old schema2 busybox digests moved onto the OCI prepared base, which flipped kaniko's output to OCI (it inherits the base media type), so their now-stale `--provenance=false` is dropped to keep both sides OCI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable BusyBox and Alpine base image repositories during integration builds.
  * Added consistent base-image setup across supported build environments.

* **Bug Fixes**
  * Improved image comparison accuracy by reducing unnecessary ignored layer differences.
  * Updated integration coverage for configurable image sources and build provenance behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->