### PR TITLE
add --image-format flag to pin output media type

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `--cleanup`](#flag---cleanup)
       - [Flag `--compression`](#flag---compression)
       - [Flag `--compression-level`](#flag---compression-level)
+      - [Flag `--image-format`](#flag---image-format)
       - [Flag `--compressed-caching`](#flag---compressed-caching)
       - [Flag `--context-sub-path`](#flag---context-sub-path)
       - [Flag `--credential-helpers`](#flag---credential-helpers)
@@ -756,6 +757,10 @@ Use this flag to select the compression algorithm `[gzip, zstd]`. Defaults to `g
 #### Flag `--compression-level`
 
 Use this flag to select the compression level. Defaults to `-1` (no compression)
+
+#### Flag `--image-format`
+
+Use this flag to select the output image media type `[docker, oci]`. `docker` writes a Docker schema2 manifest, `oci` writes an OCI image manifest. When unset, kaniko inherits the format of the base image.
 
 #### Flag `--compressed-caching`
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -277,6 +277,7 @@ func AddKanikoOptionsFlags(cmd *cobra.Command, opts *config.KanikoOptions) {
 	cmd.Flags().StringVarP(&opts.ImageNameTagDigestFile, "image-name-tag-with-digest-file", "", "", "Specify a file to save the image name w/ image tag w/ digest of the built image to.")
 	cmd.Flags().StringVarP(&opts.OCILayoutPath, "oci-layout-path", "", "", "Path to save the OCI image layout of the built image.")
 	cmd.Flags().VarP(&opts.Compression, "compression", "", "Compression algorithm (gzip, zstd)")
+	cmd.Flags().VarP(&opts.ImageFormat, "image-format", "", "Output image media type (docker, oci). Defaults to inheriting the format of the base image.")
 	cmd.Flags().IntVarP(&opts.CompressionLevel, "compression-level", "", -1, "Compression level")
 	cmd.Flags().BoolVarP(&opts.Cache, "cache", "", false, "Use cache when building image")
 	cmd.Flags().BoolVarP(&opts.CompressedCaching, "compressed-caching", "", true, "Compress the cached layers. Decreases build time, but increases memory usage.")

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -154,6 +154,12 @@ var RootCmd = &cobra.Command{
 			if opts.ImageFormat == config.ImageFormatDocker && opts.Compression == config.ZStd {
 				return errors.New("--compression=zstd cannot be used with --image-format=docker, the Docker schema2 format has no zstd layer media type, use --image-format=oci")
 			}
+			if opts.TarPath != "" && opts.ImageFormat == config.ImageFormatOCI {
+				return errors.New("--tar-path writes a Docker schema2 tarball and cannot be used with --image-format=oci, use --oci-layout-path to write an OCI image")
+			}
+			if opts.TarPath != "" && opts.Compression == config.ZStd {
+				return errors.New("--compression=zstd cannot be used with --tar-path, the Docker schema2 tarball has no zstd layer media type, use --oci-layout-path for zstd layers")
+			}
 			if err := cacheFlagsValid(); err != nil {
 				return fmt.Errorf("cache flags invalid: %w", err)
 			}

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -151,6 +151,9 @@ var RootCmd = &cobra.Command{
 			if !opts.NoPush && len(opts.Destinations) == 0 {
 				return errors.New("you must provide --destination, or use --no-push")
 			}
+			if opts.ImageFormat == config.ImageFormatDocker && opts.Compression == config.ZStd {
+				return errors.New("--compression=zstd cannot be used with --image-format=docker, the Docker schema2 format has no zstd layer media type, use --image-format=oci")
+			}
 			if err := cacheFlagsValid(); err != nil {
 				return fmt.Errorf("cache flags invalid: %w", err)
 			}

--- a/integration/dockerfiles/Dockerfile_test_issue_mz849
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz849
@@ -1,0 +1,4 @@
+# mz849: --image-format=docker forces Docker schema2 output
+# and overrides the OCI scratch base.
+FROM scratch
+COPY context/foo /foo

--- a/integration/images.go
+++ b/integration/images.go
@@ -135,7 +135,6 @@ var additionalDockerFlagsMap = map[string][]string{
 	// provenance forces ociv1 on buildkit but for these images we emit dockerv2 in kaniko
 	"Dockerfile_test_cross_compile":                {"--platform=linux/" + crossCompileArch},
 	"Dockerfile_test_issue_mz849":                  {"--provenance=false"},
-	"Dockerfile_test_mv_add":                       {"--provenance=false"},
 	"Dockerfile_test_snapshotter_ignorelist":       {"--provenance=false"},
 	"Dockerfile_test_whitelist":                    {"--provenance=false"},
 	"Dockerfile_test_volume_4":                     {"--provenance=false"},

--- a/integration/images.go
+++ b/integration/images.go
@@ -134,6 +134,8 @@ var additionalDockerFlagsMap = map[string][]string{
 	"Dockerfile_test_issue_mz661": {"--secret=id=kaniko,src=context/foo"},
 	// provenance forces ociv1 on buildkit but for these images we emit dockerv2 in kaniko
 	"Dockerfile_test_cross_compile":                {"--platform=linux/" + crossCompileArch},
+	"Dockerfile_test_issue_mz849":                  {"--provenance=false"},
+	"Dockerfile_test_mv_add":                       {"--provenance=false"},
 	"Dockerfile_test_snapshotter_ignorelist":       {"--provenance=false"},
 	"Dockerfile_test_whitelist":                    {"--provenance=false"},
 	"Dockerfile_test_volume_4":                     {"--provenance=false"},
@@ -176,6 +178,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_issue_mz822":                {"--cache=true", "--cache-copy-layers=true"},
 	"Dockerfile_test_issue_mz824":                {"--cache=true"},
 	"Dockerfile_test_issue_519":                  {"--target=final_stage,nosquash1,nosquash2"},
+	"Dockerfile_test_issue_mz849":                {"--image-format=docker"},
 	"Dockerfile_test_multistage_args_issue_1911": {"--target=base-custom2,nosquash1,nosquash2,nosquash3"},
 	"Dockerfile_test_cmd":                        {"--target=final,nosquash"},
 	"Dockerfile_test_issue_mz247":                {"--target=final,nosquash"},

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -77,6 +77,7 @@ type KanikoOptions struct {
 	ImageNameTagDigestFile       string
 	OCILayoutPath                string
 	Compression                  Compression
+	ImageFormat                  ImageFormat
 	CompressionLevel             int
 	ImageFSExtractRetry          int
 	SingleSnapshot               bool
@@ -180,6 +181,34 @@ func (c *Compression) Set(v string) error {
 
 func (c *Compression) Type() string {
 	return "compression"
+}
+
+// ImageFormat is the output image media type
+// unset means inherit from the base image (legacy behaviour)
+type ImageFormat string
+
+const (
+	ImageFormatInherit ImageFormat = ""
+	ImageFormatDocker  ImageFormat = "docker"
+	ImageFormatOCI     ImageFormat = "oci"
+)
+
+func (f *ImageFormat) String() string {
+	return string(*f)
+}
+
+func (f *ImageFormat) Set(v string) error {
+	switch v {
+	case "docker", "oci":
+		*f = ImageFormat(v)
+		return nil
+	default:
+		return errors.New(`must be either "docker" or "oci"`)
+	}
+}
+
+func (f *ImageFormat) Type() string {
+	return "imageformat"
 }
 
 // WarmerOptions are options that are set by command line arguments to the cache warmer.

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -102,7 +102,10 @@ func newStageBuilder(sourceImage v1.Image, args *dockerfile.BuildArgs, opts *con
 	if !stage.Push {
 		_opts.Labels = []string{}
 	}
-	sourceImage = applyImageFormat(sourceImage, opts.ImageFormat)
+	sourceImage, err := applyImageFormat(sourceImage, opts.ImageFormat)
+	if err != nil {
+		return nil, err
+	}
 	imageConfig, err := initializeConfig(sourceImage, &_opts)
 	if err != nil {
 		return nil, err
@@ -749,20 +752,14 @@ func extractMediaTypeVendor(mt types.MediaType) string {
 	return types.DockerVendorPrefix
 }
 
-func applyImageFormat(image v1.Image, format config.ImageFormat) v1.Image {
+func applyImageFormat(image v1.Image, format config.ImageFormat) (v1.Image, error) {
 	switch format {
 	case config.ImageFormatOCI:
-		return mutate.ConfigMediaType(
-			mutate.MediaType(image, types.OCIManifestSchema1),
-			types.OCIConfigJSON,
-		)
+		return image_util.WithMediaType(image, types.OCIManifestSchema1)
 	case config.ImageFormatDocker:
-		return mutate.ConfigMediaType(
-			mutate.MediaType(image, types.DockerManifestSchema2),
-			types.DockerConfigJSON,
-		)
+		return image_util.WithMediaType(image, types.DockerManifestSchema2)
 	default:
-		return image
+		return image, nil
 	}
 }
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -102,6 +102,7 @@ func newStageBuilder(sourceImage v1.Image, args *dockerfile.BuildArgs, opts *con
 	if !stage.Push {
 		_opts.Labels = []string{}
 	}
+	sourceImage = applyImageFormat(sourceImage, opts.ImageFormat)
 	imageConfig, err := initializeConfig(sourceImage, &_opts)
 	if err != nil {
 		return nil, err
@@ -744,6 +745,23 @@ func extractMediaTypeVendor(mt types.MediaType) string {
 		return types.OCIVendorPrefix
 	}
 	return types.DockerVendorPrefix
+}
+
+func applyImageFormat(image v1.Image, format config.ImageFormat) v1.Image {
+	switch format {
+	case config.ImageFormatOCI:
+		return mutate.ConfigMediaType(
+			mutate.MediaType(image, types.OCIManifestSchema1),
+			types.OCIConfigJSON,
+		)
+	case config.ImageFormatDocker:
+		return mutate.ConfigMediaType(
+			mutate.MediaType(image, types.DockerManifestSchema2),
+			types.DockerConfigJSON,
+		)
+	default:
+		return image
+	}
 }
 
 // https://github.com/opencontainers/image-spec/blob/main/media-types.md#compatibility-matrix

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -717,6 +717,8 @@ func saveSnapshotToLayer(tarPath string, imageMediaType types.MediaType, opts *c
 		} else {
 			layerOpts = append(layerOpts, tarball.WithMediaType(types.OCILayer))
 		}
+	} else if opts.Compression == config.ZStd {
+		logrus.Warn("ignoring --compression=zstd, the Docker schema2 output format has no zstd layer media type, use --image-format=oci for zstd layers")
 	}
 
 	layer, err := tarball.LayerFromFile(tarPath, layerOpts...)

--- a/pkg/image/transform.go
+++ b/pkg/image/transform.go
@@ -18,6 +18,7 @@ package image
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -181,4 +182,82 @@ func (n *noAnnotationsImage) RawManifest() ([]byte, error) {
 
 func (n *noAnnotationsImage) Digest() (v1.Hash, error) {
 	return partial.Digest(n)
+}
+
+func WithMediaType(img v1.Image, manifestMT types.MediaType) (v1.Image, error) {
+	vendor := mediaTypeVendor(manifestMT)
+	configMT := types.DockerConfigJSON
+	if vendor == types.OCIVendorPrefix {
+		configMT = types.OCIConfigJSON
+	}
+	relabeled, err := relabelLayers(img, vendor)
+	if err != nil {
+		return nil, err
+	}
+	return mutate.ConfigMediaType(mutate.MediaType(relabeled, manifestMT), configMT), nil
+}
+
+func relabelLayers(img v1.Image, vendor string) (v1.Image, error) {
+	man, err := img.Manifest()
+	if err != nil {
+		return nil, err
+	}
+	relabeled := man.DeepCopy()
+	for i := range relabeled.Layers {
+		mt, err := relabelLayerMediaType(relabeled.Layers[i].MediaType, vendor)
+		if err != nil {
+			return nil, err
+		}
+		relabeled.Layers[i].MediaType = mt
+	}
+	return &layerRelabeledImage{Image: img, manifest: relabeled}, nil
+}
+
+type layerRelabeledImage struct {
+	v1.Image
+	manifest *v1.Manifest
+}
+
+func (i *layerRelabeledImage) Manifest() (*v1.Manifest, error) {
+	return i.manifest.DeepCopy(), nil
+}
+
+func (i *layerRelabeledImage) RawManifest() ([]byte, error) {
+	return json.Marshal(i.manifest)
+}
+
+func mediaTypeVendor(mt types.MediaType) string {
+	if strings.Contains(string(mt), types.OCIVendorPrefix) {
+		return types.OCIVendorPrefix
+	}
+	return types.DockerVendorPrefix
+}
+
+func relabelLayerMediaType(mt types.MediaType, vendor string) (types.MediaType, error) {
+	if mediaTypeVendor(mt) == vendor {
+		return mt, nil
+	}
+	switch vendor {
+	case types.OCIVendorPrefix:
+		switch mt {
+		case types.DockerLayer:
+			return types.OCILayer, nil
+		case types.DockerUncompressedLayer:
+			return types.OCIUncompressedLayer, nil
+		case types.DockerForeignLayer:
+			return types.OCIRestrictedLayer, nil
+		}
+	case types.DockerVendorPrefix:
+		switch mt {
+		case types.OCILayer:
+			return types.DockerLayer, nil
+		case types.OCIUncompressedLayer:
+			return types.DockerUncompressedLayer, nil
+		case types.OCIRestrictedLayer:
+			return types.DockerForeignLayer, nil
+		case types.OCILayerZStd:
+			return "", fmt.Errorf("cannot relabel zstd layer %q to docker schema2, which has no zstd media type, use --image-format=oci", mt)
+		}
+	}
+	return "", fmt.Errorf("cannot relabel layer media type %q to %s", mt, vendor)
 }

--- a/pkg/image/transform.go
+++ b/pkg/image/transform.go
@@ -210,12 +210,13 @@ func relabelLayers(img v1.Image, vendor string) (v1.Image, error) {
 		}
 		relabeled.Layers[i].MediaType = mt
 	}
-	return &layerRelabeledImage{Image: img, manifest: relabeled}, nil
+	return &layerRelabeledImage{Image: img, manifest: relabeled, vendor: vendor}, nil
 }
 
 type layerRelabeledImage struct {
 	v1.Image
 	manifest *v1.Manifest
+	vendor   string
 }
 
 func (i *layerRelabeledImage) Manifest() (*v1.Manifest, error) {
@@ -224,6 +225,48 @@ func (i *layerRelabeledImage) Manifest() (*v1.Manifest, error) {
 
 func (i *layerRelabeledImage) RawManifest() ([]byte, error) {
 	return json.Marshal(i.manifest)
+}
+
+func (i *layerRelabeledImage) relabel(l v1.Layer) (v1.Layer, error) {
+	mt, err := l.MediaType()
+	if err != nil {
+		return nil, err
+	}
+	relabeled, err := relabelLayerMediaType(mt, i.vendor)
+	if err != nil {
+		return nil, err
+	}
+	return &mediaTypeLayer{Layer: l, mediaType: relabeled}, nil
+}
+
+func (i *layerRelabeledImage) Layers() ([]v1.Layer, error) {
+	layers, err := i.Image.Layers()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]v1.Layer, len(layers))
+	for j, l := range layers {
+		if out[j], err = i.relabel(l); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (i *layerRelabeledImage) LayerByDigest(h v1.Hash) (v1.Layer, error) {
+	l, err := i.Image.LayerByDigest(h)
+	if err != nil {
+		return nil, err
+	}
+	return i.relabel(l)
+}
+
+func (i *layerRelabeledImage) LayerByDiffID(h v1.Hash) (v1.Layer, error) {
+	l, err := i.Image.LayerByDiffID(h)
+	if err != nil {
+		return nil, err
+	}
+	return i.relabel(l)
 }
 
 func mediaTypeVendor(mt types.MediaType) string {


### PR DESCRIPTION
fixes #849.

Kaniko's output media type is currently decided by whatever the base image happens to be, with a Docker schema2 fallback. That is outside the user's control and changes silently when a registry re-publishes a tag in a different format, which makes the output format unpredictable. This adds `--image-format=docker|oci` so the output format is an explicit, stable choice. The format is forced at a single chokepoint in `newStageBuilder`, so it propagates to every stage including `FROM scratch` and subsumes `FF_KANIKO_OCI_SCRATCH_BASE`.

This is phase 1 of the migration: the flag is purely additive and the unset default keeps today's inherit-from-base behavior, so existing builds are bit-for-bit unchanged. The default flip to `oci` is a later phase tracked on #849.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--image-format` option to select Docker or OCI output, or inherit the base image format.
  * Added manifest/layer media-type conversion to match the selected output format.
* **Bug Fixes**
  * Added compatibility validation for image format vs compression and tar output.
  * Added a warning when zstd compression is used with Docker-format output.
* **Documentation**
  * Updated the README to document `--image-format` and default inheritance behavior.
* **Tests**
  * Added an integration test Dockerfile to cover forced Docker output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->