### PR TITLE
Fix inconsistent feature flag defaults

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -403,7 +403,7 @@ func checkNoDeprecatedFlags() {
 		logrus.Warn("Flag --skip-unused-stages is deprecated. This is the new default behaviour. If you want to build multiple independent stages pass them as --target instead")
 	}
 
-	if !config.EnvBool("FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE") {
+	if !config.EnvBoolDefault("FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE", true) {
 		if opts.PreserveContext && !opts.PreCleanup {
 			logrus.Warn("--preserve-context without --pre-cleanup restores the original context between stages; this is deprecated and will be removed. Use --mount=type=secret for secrets. Set FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE=1 to opt into the new behaviour now.")
 		}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -600,7 +600,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 				util.Assert("executor.build.metadata-only", command.MetadataOnly(), "build: non-MetadataOnly command %q ran without unpacked filesystem in stage %d", command.String(), s.index)
 			}
 			_, isVolume := command.(*commands.VolumeCommand)
-			volumeCreatesFiles := isVolume && !config.EnvBool("FF_KANIKO_VOLUME_SKIP_MKDIR")
+			volumeCreatesFiles := isVolume && !config.EnvBoolDefault("FF_KANIKO_VOLUME_SKIP_MKDIR", true)
 			if command.MetadataOnly() && !opts.SingleSnapshot && !volumeCreatesFiles {
 				// MetadataOnly commands must not change or even need the filesystem.
 				util.Assert("executor.build.without-fs", snapshotted == 0, "build: MetadataOnly command %q snapshotted %d file(s)", command.String(), snapshotted)
@@ -659,7 +659,7 @@ func takeSnapshot(files []string, shdDelete bool, opts *config.KanikoOptions, sn
 	if files == nil || opts.SingleSnapshot {
 		snapshot, snapshotted, err = snapshotter.TakeSnapshotFS()
 	} else {
-		if !config.EnvBool("FF_KANIKO_VOLUME_SKIP_MKDIR") {
+		if !config.EnvBoolDefault("FF_KANIKO_VOLUME_SKIP_MKDIR", true) {
 			// Volumes are very weird. They get snapshotted in the next command.
 			files = append(files, util.Volumes()...)
 		}


### PR DESCRIPTION
Fixes #852

`FF_KANIKO_VOLUME_SKIP_MKDIR` and `FF_KANIKO_DEPRECATE_INTER_STAGE_RESTORE` default to `true` per the README, but a few sites read them with the bare `EnvBool` helper, which defaults to `false`. That split default made an unset `FF_KANIKO_VOLUME_SKIP_MKDIR` panic on `executor.build.without-fs` for a metadata command after `VOLUME` under `--cache`, and made `root.go` warn users to opt into behaviour that was already on.

Now both are read through `EnvBoolDefault(..., true)` everywhere. Audited the rest of the tree; these were the only flags with conflicting defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default behavior for deprecated flag warnings to ensure they appear when the related feature flag is unset.
  * Improved volume handling during builds by preventing automatic directory creation and excluding volume paths from snapshots by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->