### PR TITLE
mz851: keep reproducible output a consistent dockerv2 manifest

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz851
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz851
@@ -1,0 +1,16 @@
+# mz851: building an OCI base with --reproducible and
+# FF_KANIKO_REPRODUCIBLE_PRESERVE_BASE_LAYERS flipped the output to a docker
+# schema2 manifest while keeping the OCI base layer descriptors verbatim. The
+# resulting docker manifest carrying OCI layer media types is malformed and
+# breaks strict readers like dockle.
+#
+# Breaks on v1.28.0 behind FF_KANIKO_REPRODUCIBLE_PRESERVE_BASE_LAYERS. The
+# cause is mutate.Canonical rebuilding the image on an empty (docker) base, so
+# --reproducible alone already rewrites to docker, and ReplaceBase then splices
+# the pristine OCI base layers back on top of that docker manifest.
+#
+# Pin an OCI base and add one RUN so kaniko produces a layer of its own. With
+# the fix the preserved base layers are relabeled so the output manifest,
+# config, and every layer are consistently dockerv2.
+FROM debian:12.10@sha256:6bc30d909583f38600edd6609e29eb3fb284ab8affce8d0389f332fc91c2dd91
+RUN echo 'hi' > /root/hi.txt

--- a/integration/images.go
+++ b/integration/images.go
@@ -499,6 +499,7 @@ func NewDockerFileBuilder() *DockerFileBuilder {
 	d.TestReproducibleDockerfiles = map[string]struct{}{
 		"Dockerfile_test_copy_reproducible": {},
 		"Dockerfile_test_issue_mz731":       {},
+		"Dockerfile_test_issue_mz851":       {},
 	}
 	return &d
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -976,7 +976,11 @@ func TestReproducible(t *testing.T) {
 			t.Fatalf("build %s -> %s: %v", dockerfile, ref, err)
 		}
 	}
-	const baseRef = "alpine@sha256:5ce5f501c457015c4b91f91a15ac69157d9b06f1a75cf9107bf2b62e0843983a"
+	baseRefs := map[string]string{
+		"Dockerfile_test_copy_reproducible": "alpine@sha256:5ce5f501c457015c4b91f91a15ac69157d9b06f1a75cf9107bf2b62e0843983a",
+		"Dockerfile_test_issue_mz731":       "alpine@sha256:5ce5f501c457015c4b91f91a15ac69157d9b06f1a75cf9107bf2b62e0843983a",
+		"Dockerfile_test_issue_mz851":       "debian@sha256:6bc30d909583f38600edd6609e29eb3fb284ab8affce8d0389f332fc91c2dd91",
+	}
 	for dockerfile := range imageBuilder.TestReproducibleDockerfiles {
 		if match, _ := filepath.Match(config.dockerfilesPattern, dockerfile); !match {
 			continue
@@ -991,7 +995,7 @@ func TestReproducible(t *testing.T) {
 			containerDiff(t, ref0, ref1)
 
 			// mz731: make sure the inherited base layers were not mutated.
-			base := layerDigests(t, baseRef)
+			base := layerDigests(t, baseRefs[dockerfile])
 			kaniko := layerDigests(t, ref0)
 			testutil.CheckDeepEqual(t, base, kaniko[:len(base)])
 		})

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -1306,6 +1306,10 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 			if len(opts.Annotations) > 0 {
 				sourceImage = mutate.Annotations(sourceImage, opts.Annotations).(v1.Image)
 			}
+			err = image_util.AssertConsistentMediaType(sourceImage)
+			if err != nil {
+				return nil, err
+			}
 			pushImage = sourceImage
 		}
 		if stage.Final {

--- a/pkg/image/transform.go
+++ b/pkg/image/transform.go
@@ -18,11 +18,13 @@ package image
 
 import (
 	"encoding/json"
+	"strings"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/osscontainertools/kaniko/pkg/util"
 )
 
@@ -98,6 +100,30 @@ func ReplaceBase(img, base v1.Image) (v1.Image, error) {
 	finalCfg.RootFS = stackedCfg.RootFS
 	finalCfg.History = stackedCfg.History
 	return mutate.ConfigFile(stacked, finalCfg)
+}
+
+func AssertConsistentMediaType(img v1.Image) error {
+	man, err := img.Manifest()
+	if err != nil {
+		return err
+	}
+	oci, docker := false, false
+	classify := func(mt types.MediaType) {
+		s := string(mt)
+		switch {
+		case strings.Contains(s, types.OCIVendorPrefix):
+			oci = true
+		case strings.Contains(s, types.DockerVendorPrefix):
+			docker = true
+		}
+	}
+	classify(man.MediaType)
+	classify(man.Config.MediaType)
+	for _, l := range man.Layers {
+		classify(l.MediaType)
+	}
+	util.Assert("image.consistent-media-type", !(oci && docker), "manifest mixes OCI and docker media types")
+	return nil
 }
 
 // WithoutAnnotations returns an image whose manifest has no annotations.

--- a/pkg/image/transform.go
+++ b/pkg/image/transform.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/osscontainertools/kaniko/pkg/util"
+	"github.com/sirupsen/logrus"
 )
 
 // ReplaceBase returns img with its first len(base.Layers()) layers and first
@@ -79,7 +80,21 @@ func ReplaceBase(img, base v1.Image) (v1.Image, error) {
 		}
 		if !h.EmptyLayer {
 			if li < len(baseLayers) {
-				a.Layer = baseLayers[li]
+				mt, err := baseLayers[li].MediaType()
+				if err != nil {
+					return nil, err
+				}
+				switch mt {
+				case types.DockerLayer, types.DockerUncompressedLayer, types.DockerForeignLayer:
+					a.Layer = baseLayers[li]
+				case types.OCILayer:
+					a.Layer = &mediaTypeLayer{Layer: baseLayers[li], mediaType: types.DockerLayer}
+				case types.OCIUncompressedLayer:
+					a.Layer = &mediaTypeLayer{Layer: baseLayers[li], mediaType: types.DockerUncompressedLayer}
+				default:
+					logrus.Warnf("not preserving base layers: base image has %s layers, incompatible with a reproducible dockerv2 image", mt)
+					return img, nil
+				}
 			} else {
 				a.Layer = imgLayers[li]
 			}
@@ -100,6 +115,15 @@ func ReplaceBase(img, base v1.Image) (v1.Image, error) {
 	finalCfg.RootFS = stackedCfg.RootFS
 	finalCfg.History = stackedCfg.History
 	return mutate.ConfigFile(stacked, finalCfg)
+}
+
+type mediaTypeLayer struct {
+	v1.Layer
+	mediaType types.MediaType
+}
+
+func (l *mediaTypeLayer) MediaType() (types.MediaType, error) {
+	return l.mediaType, nil
 }
 
 func AssertConsistentMediaType(img v1.Image) error {


### PR DESCRIPTION
Fixes #851

A reproducible build always canonicalizes the image to dockerv2, since mutate.Canonical rebuilds it on an empty docker base. With FF_KANIKO_REPRODUCIBLE_PRESERVE_BASE_LAYERS the ReplaceBase splice then put the pristine OCI base layers back on top of that docker manifest, so the result was a docker schema2 manifest carrying OCI layer descriptors. That hybrid is malformed and strict readers such as dockle reject it.

The preserved base layers are now relabeled to their dockerv2 media type as they are spliced, which is a descriptor-only change that keeps each layer blob and digest intact. A base layer that has no digest-preserving docker form (zstd) has its preservation skipped with a warning, falling back to the recompressed canonical layer. A new assertion at the push chokepoint fails the build if the output manifest ever mixes OCI and docker media types, and the mz851 reproducible integration test exercises an OCI base so this path is covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image handling when combining OCI and Docker-format layers.
  * Prevented builds from producing manifests with inconsistent media types.
  * Added safer handling for unsupported base-layer formats, avoiding invalid image transformations.
* **Tests**
  * Expanded reproducibility coverage for images using pinned OCI base layers.
  * Added validation for consistent output manifests, configurations, and layers across supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->