### PR TITLE
mz863: apply COPY --chmod to implicitly created parent directories

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz863
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz863
@@ -1,8 +1,12 @@
-FROM busybox
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
 
 # mz863: COPY --chmod must apply the mode to parent directories that the copy
 # creates implicitly, matching buildkit. The single file copy path created every
 # implicit parent with a fixed 0755 while only the file itself got the chmod.
 COPY --chmod=0600 context/foo /dest/foo
 COPY --chmod=0705 context/foo /nested/a/b/foo
-RUN stat -c '%a %n' /dest /nested /nested/a /nested/a/b
+RUN test "$(stat -c '%a' /dest)" = "600" \
+ && test "$(stat -c '%a' /nested)" = "705" \
+ && test "$(stat -c '%a' /nested/a)" = "705" \
+ && test "$(stat -c '%a' /nested/a/b)" = "705"

--- a/integration/dockerfiles/Dockerfile_test_issue_mz863
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz863
@@ -1,0 +1,8 @@
+FROM busybox
+
+# mz863: COPY --chmod must apply the mode to parent directories that the copy
+# creates implicitly, matching buildkit. The single file copy path created every
+# implicit parent with a fixed 0755 while only the file itself got the chmod.
+COPY --chmod=0600 context/foo /dest/foo
+COPY --chmod=0705 context/foo /nested/a/b/foo
+RUN stat -c '%a %n' /dest /nested /nested/a /nested/a/b

--- a/pkg/buildcontext/gcs.go
+++ b/pkg/buildcontext/gcs.go
@@ -73,7 +73,7 @@ func getTarFromBucket(bucketName, filepathInBucket, directory string) (string, e
 	}
 	defer reader.Close()
 	tarPath := filepath.Join(directory, constants.ContextTar)
-	if err := util.CreateFile(tarPath, reader, 0o600, 0, 0); err != nil {
+	if err := util.CreateFile(tarPath, reader, 0o600, 0o755, 0, 0); err != nil {
 		return "", err
 	}
 	logrus.Debugf("Copied tarball %s from GCS bucket %s to %s", constants.ContextTar, bucketName, tarPath)

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -168,7 +168,7 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 		}
 
 		srcFile := strings.NewReader(data)
-		err = util.CreateFile(destPath, srcFile, chmod.Apply(0o644), uint32(uid), uint32(gid))
+		err = util.CreateFile(destPath, srcFile, chmod.Apply(0o644), chmod.Apply(0o755), uint32(uid), uint32(gid))
 		if err != nil {
 			return fmt.Errorf("creating file: %w", err)
 		}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -682,9 +682,9 @@ func resetFileOwnershipIfNotMatching(path string, newUID, newGID uint32) error {
 }
 
 // CreateFile creates a file at path and copies over contents from the reader
-func CreateFile(path string, reader io.Reader, perm os.FileMode, uid uint32, gid uint32) error {
+func CreateFile(path string, reader io.Reader, perm os.FileMode, dirPerm os.FileMode, uid uint32, gid uint32) error {
 	// Create directory path if it doesn't exist
-	if err := createParentDirectory(path, int(uid), int(gid)); err != nil {
+	if err := createParentDirectory(path, int(uid), int(gid), dirPerm); err != nil {
 		return fmt.Errorf("creating parent dir: %w", err)
 	}
 
@@ -734,7 +734,7 @@ func DownloadFileToDest(rawurl, dest string, uid, gid int64, chmod fs.FileMode) 
 		return fmt.Errorf("invalid response status %d", resp.StatusCode)
 	}
 
-	if err := CreateFile(dest, resp.Body, chmod, uint32(uid), uint32(gid)); err != nil {
+	if err := CreateFile(dest, resp.Body, chmod, 0o755, uint32(uid), uint32(gid)); err != nil {
 		return err
 	}
 	mTime := time.Time{}
@@ -957,7 +957,7 @@ func CopyFile(src, dest string, context FileContext, uid, gid int64, chmod mode.
 		perm = chmod.Apply(fi.Mode())
 	}
 
-	err = CreateFile(dest, srcFile, perm, uint32(uid), uint32(gid))
+	err = CreateFile(dest, srcFile, perm, chmod.Apply(0o755), uint32(uid), uint32(gid))
 	if err != nil {
 		return false, err
 	}
@@ -985,7 +985,7 @@ func CopyFileInternal(src, dest string, _ FileContext) error {
 	gid := fi.Sys().(*syscall.Stat_t).Gid
 	mode := fi.Mode()
 
-	err = CreateFile(dest, srcFile, mode, uid, gid)
+	err = CreateFile(dest, srcFile, mode, 0o755, uid, gid)
 	if err != nil {
 		return err
 	}
@@ -1327,7 +1327,11 @@ func CopyTimestamps(src string, dest string) error {
 	return nil
 }
 
-func createParentDirectory(path string, uid int, gid int) error {
+func createParentDirectory(path string, uid int, gid int, dirPerm ...os.FileMode) error {
+	perm := os.FileMode(0o755)
+	if len(dirPerm) > 0 && config.FF.CopyChmodOnImplicitDirs {
+		perm = dirPerm[0]
+	}
 	baseDir := filepath.Dir(path)
 	if info, err := os.Lstat(baseDir); os.IsNotExist(err) {
 		logrus.Tracef("BaseDir %s for file %s does not exist. Creating.", baseDir, path)
@@ -1343,7 +1347,7 @@ func createParentDirectory(path string, uid int, gid int) error {
 			dir := dirs[i]
 
 			if _, err := os.Lstat(dir); os.IsNotExist(err) {
-				err = os.Mkdir(dir, 0o755)
+				err = os.Mkdir(dir, perm)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Fixes #863

`COPY --chmod` applied the mode to the copied file but left implicitly created parent directories at a fixed 0755, so kaniko and buildkit produced different directory permissions for the same Dockerfile. `FF_KANIKO_COPY_CHMOD_ON_IMPLICIT_DIRS` was meant to cover this but only wired into the directory copy path, never the single file copy that creates parents through `createParentDirectory`. This threads the implicit-dir permission through `CreateFile` and `createParentDirectory` so the flag applies on that path too, matching buildkit including the umask handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed permissions for implicitly created parent directories during copy and download operations when chmod-on-implicit-dirs is enabled, ensuring nested paths use the intended directory modes.
  - Updated heredoc destination creation to apply the correct permissions to both the generated file and its parent directories.
  - Adjusted permissions for generated local tar archives to use directory-appropriate modes.
- **Tests**
  - Added an integration Dockerfile test (mz863) to verify correct permission propagation for `COPY --chmod`, including implicitly created parent directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->