### PR TITLE
mz868: tolerate dangling symlink when resolving COPY destination

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz868
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz868
@@ -1,0 +1,8 @@
+FROM alpine
+
+# mz868: a COPY whose destination resolves through a dangling symlink aborted the
+# build on kaniko v1.28.0 with "failed to eval symlinks", because resolveIfSymlink
+# lstats the missing target. docker writes through the link, so the build succeeds.
+RUN mkdir -p /dest && ln -s /nowhere-target /dest/linkS
+COPY context/foo /dest/linkS
+RUN readlink /dest/linkS && cat /dest/linkS

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -290,23 +290,20 @@ func resolveIfSymlink(destPath string) (string, error) {
 
 	newPath := destPath
 	for newPath != "/" {
-		_, err := os.Lstat(newPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				dir, file := filepath.Split(newPath)
-				newPath = filepath.Clean(dir)
-				nonexistentPaths = append(nonexistentPaths, file)
-				continue
-			} else {
-				return "", fmt.Errorf("failed to lstat: %w", err)
-			}
+		resolved, err := filepath.EvalSymlinks(newPath)
+		if err == nil {
+			newPath = resolved
+			break
 		}
-
-		newPath, err = filepath.EvalSymlinks(newPath)
-		if err != nil {
+		if !os.IsNotExist(err) {
 			return "", fmt.Errorf("failed to eval symlinks: %w", err)
 		}
-		break
+		// mz868: newPath is missing or points through a dangling symlink. Peel the
+		// last component and keep resolving the parent so the destination is created
+		// rather than aborting the build.
+		dir, file := filepath.Split(newPath)
+		newPath = filepath.Clean(dir)
+		nonexistentPaths = append(nonexistentPaths, file)
 	}
 
 	for i := len(nonexistentPaths) - 1; i >= 0; i-- {


### PR DESCRIPTION
Fixes #868

A COPY whose destination resolves through a dangling symlink aborted the build. `resolveIfSymlink` walks the destination and calls `filepath.EvalSymlinks` on the deepest existing component, which lstats the missing target of a dangling link and returns an error, surfaced as `failed to eval symlinks`. docker writes through the link instead and builds fine. This drives the walk off `EvalSymlinks` directly and treats its `IsNotExist` result, whether the path is missing or points through a dangling symlink, as a component to be created rather than a hard error, so the destination resolves to the lexical path and the copy proceeds.