### PR TITLE
mz334: eliminate and squash fully cached stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `FF_KANIKO_UNTAR_SKIP_ROOT`](#flag-ff_kaniko_untar_skip_root)
       - [Flag `FF_KANIKO_RUN_HONOR_GROUP`](#flag-ff_kaniko_run_honor_group)
       - [Flag `FF_KANIKO_EXPAND_HEREDOC`](#flag-ff_kaniko_expand_heredoc)
+      - [Flag `FF_KANIKO_SKIP_CACHED_STAGES`](#flag-ff_kaniko_skip_cached_stages)
     - [Assertion Overrides](#assertion-overrides)
     - [Telemetry](#telemetry)
     - [Debug Image](#debug-image)
@@ -1393,6 +1394,13 @@ Becomes default in `v1.29.0`.
 
 Docker applies Dockerfile word-expansion to a `COPY` or `ADD` heredoc body when the delimiter is unquoted, so `${VAR}` expands and `\${VAR}` keeps the literal text. A quoted delimiter (`<<'EOF'`) leaves the body verbatim. kaniko writes the body verbatim in every case, so the expanded files diverge from Docker.
 Set this flag to `true` to expand build args and env in unquoted `COPY` and `ADD` heredoc bodies.
+Defaults to `false`.
+Becomes default in `v1.29.0`.
+
+#### Flag `FF_KANIKO_SKIP_CACHED_STAGES`
+
+When a multi-stage build uses `COPY --from=<stage>`, the downstream cache key depends on the copied files. So the entire source stage has to be built and unpacked, only to then realize that we had a cache hit and can throw away the upstream stage. We recently introduced `FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY`, `FF_KANIKO_CACHE_LOOKAHEAD` and `FF_KANIKO_ROLLING_CACHE_KEY`, with that we can know a-priori whether we will have a cache hit or not. `FF_KANIKO_SKIP_CACHED_STAGES` is the logical conclusion then, it simply runs another elision pass over the now updated list of stages and drops all stages that are no longer required to be built. Where a key cannot be inferred the stage is built as before. A fully cached build collapses into a single stage with nothing to unpack.
+Set this flag to `true` to run the second elision pass.
 Defaults to `false`.
 Becomes default in `v1.29.0`.
 

--- a/golden/testdata/test_issue_mz334/plans/eliminated
+++ b/golden/testdata/test_issue_mz334/plans/eliminated
@@ -1,27 +1,9 @@
-FROM busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d AS first
+FROM busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d AS final
 UNPACK busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
 CACHE HIT: ec50b204a07f169d1beec66434b673ca44caf8b98ee6c98e886320969926d029
 RUN touch /blubb
-SAVE STAGE /kaniko/stages/0
-SAVE FILES [/blubb] /kaniko/deps/0
-CLEAN
-
-FROM first AS second
-UNPACK /kaniko/stages/0
 CACHE HIT: 9097bbf817837a54a5ba9b91d9d2a771a145d25f5389c96a4c3315119aa482a5
 RUN touch /bla
-SAVE STAGE /kaniko/stages/1
-CLEAN
-
-FROM second AS third
-UNPACK /kaniko/stages/1
-CACHE HIT: dd8070993f952ce8287efcf5c6b32d3d2399905c6fc8dc9b4036d4196b80e10f
-RUN touch /bli
-SAVE FILES [/bli] /kaniko/deps/2
-CLEAN
-
-FROM second AS final
-UNPACK /kaniko/stages/1
 CACHE REDIRECT HIT: 8ef1283833b79b08b093a99de08ffc3fed1fbbf8fb328f81e9d7561af0524e95
 CACHE HIT: 8ef1283833b79b08b093a99de08ffc3fed1fbbf8fb328f81e9d7561af0524e95
 COPY --from=first /blubb /blubb

--- a/golden/testdata/test_issue_mz334/test.go
+++ b/golden/testdata/test_issue_mz334/test.go
@@ -2,6 +2,16 @@ package testissuemz334
 
 import "github.com/osscontainertools/kaniko/golden/types"
 
+// shared so the elimination-off and elimination-on cases prove squashing is key-neutral
+var chainKeys = []string{
+	"ec50b204a07f169d1beec66434b673ca44caf8b98ee6c98e886320969926d029",
+	"9097bbf817837a54a5ba9b91d9d2a771a145d25f5389c96a4c3315119aa482a5",
+	"dd8070993f952ce8287efcf5c6b32d3d2399905c6fc8dc9b4036d4196b80e10f",
+	"8ef1283833b79b08b093a99de08ffc3fed1fbbf8fb328f81e9d7561af0524e95",
+	"c59fad0bd865d2ed209d0f7a29d55161a8332681a1b68abc9e98da2dca1254cb",
+	"e3d0a39d0f55303c063b93635b40f56d535f5bd2b48b770af66bf0fe61b7debc",
+}
+
 var Tests = types.GoldenTests{
 	Name:       "test_issue_mz334",
 	Dockerfile: "Dockerfile",
@@ -28,18 +38,21 @@ var Tests = types.GoldenTests{
 			Env: map[string]string{
 				"FF_KANIKO_CACHE_LOOKAHEAD":             "1",
 				"FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY": "1",
+				"FF_KANIKO_ROLLING_CACHE_KEY":           "1",
 			},
-			CachedKeys: []string{
-				"72e9e0e54e4522d381e54427f5ac6f24dd09910e1ff8d4bc7f60d02f54e2cdc3",
-				"3829b10dc17cc7bafd22450e05b7f265b73e94d46b08817d0502848b21dd69aa",
-				"256455fba386c671b4808e621379712ca6dfecce4d4e9ed2d6edab8b5e415b75",
-				"7ffdded6b9b986b59b4e27ca74ec544a28acfcbd0f87e6f848d64c2631f4d9f0",
-				"7e3daa5c6ad10774b5430117c90f8fe60002da5f2f2175c52dd094506355eb81",
-				"2aba9bf1ce0db5b0cae37fddf680713ba7cd60797cb0742498830f4267db95c0",
-				"e0a60f4194bd9f2ee44a9063f3036eda32322bc8ae7773d897e9ca27dc356fcb",
-				"2fa9a748e3206653ffc13bd26b1cb8f29117a513d4c8bb7bcd95a6a8a0618e4f",
+			CachedKeys: chainKeys,
+			Plan:       "inferred",
+		},
+		{
+			Args: []string{"--no-push", "--cache", "--cache-copy-layers"},
+			Env: map[string]string{
+				"FF_KANIKO_CACHE_LOOKAHEAD":             "1",
+				"FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY": "1",
+				"FF_KANIKO_ROLLING_CACHE_KEY":           "1",
+				"FF_KANIKO_SKIP_CACHED_STAGES":          "1",
 			},
-			Plan: "inferred",
+			CachedKeys: chainKeys,
+			Plan:       "eliminated",
 		},
 	},
 }

--- a/integration/images.go
+++ b/integration/images.go
@@ -97,6 +97,7 @@ var envsMap = map[string][]string{
 	"Dockerfile_test_issue_519":   {"DOCKER_BUILDKIT=0"},
 	"Dockerfile_test_issue_cg188": {"SECRET=blubb"},
 	"Dockerfile_test_issue_mz775": {"FF_KANIKO_CACHE_LOOKAHEAD=0"},
+	"Dockerfile_test_issue_mz334": {"FF_KANIKO_SKIP_CACHED_STAGES=1"},
 	"Dockerfile_test_issue_mz793": {"FF_KANIKO_VOLUME_SKIP_MKDIR=0"},
 	"Dockerfile_test_issue_mz473": {"KANIKO_DIR=/kaniko2"},
 	"Dockerfile_test_issue_mz661": {"KANIKO_DIR=/kaniko2"},

--- a/pkg/config/featureflags.go
+++ b/pkg/config/featureflags.go
@@ -53,6 +53,7 @@ type FeatureFlags struct {
 	RunViaTini                     bool
 	ScopedDockerignore             bool
 	SecurejoinExtraction           bool
+	SkipCachedStages               bool
 	SkipRelabelRecompress          bool
 	SkipWriteWhiteouts             bool
 	UntarSkipRoot                  bool
@@ -119,6 +120,7 @@ func InitFeatureFlags() {
 		RunViaTini:                     featureFlag("FF_KANIKO_RUN_VIA_TINI", false),
 		ScopedDockerignore:             featureFlag("FF_KANIKO_SCOPED_DOCKERIGNORE", false),
 		SecurejoinExtraction:           featureFlag("FF_KANIKO_SECUREJOIN_EXTRACTION", true),
+		SkipCachedStages:               featureFlag("FF_KANIKO_SKIP_CACHED_STAGES", false),
 		SkipRelabelRecompress:          featureFlag("FF_KANIKO_SKIP_RELABEL_RECOMPRESS", false),
 		SkipWriteWhiteouts:             featureFlag("FF_KANIKO_SKIP_WRITE_WHITEOUTS", false),
 		UntarSkipRoot:                  featureFlag("FF_KANIKO_UNTAR_SKIP_ROOT", false),

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -397,7 +397,7 @@ func MakeKanikoStages(opts *config.KanikoOptions, stages []instructions.Stage, m
 				// We squash the base stage into the current stage because,
 				// no one else depends on the base stage so it can be freely moved,
 				// the current stage might depend on other stages so it is not safe to move it.
-				kanikoStages[i] = squash(sb, s)
+				kanikoStages[i] = Squash(sb, s)
 				stagesDependencies[s.BaseImageIndex] = 0
 			}
 		}
@@ -473,7 +473,7 @@ func filterOnBuild(cmds []instructions.Command) []instructions.Command {
 	return out
 }
 
-func squash(a, b config.KanikoStage) config.KanikoStage {
+func Squash(a, b config.KanikoStage) config.KanikoStage {
 	acmds := filterOnBuild(a.Commands)
 	return config.KanikoStage{
 		Name:                   b.Name,

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -92,6 +92,54 @@ type stageCacheInfo struct {
 	cacheHits    []bool
 }
 
+// mz334: memoizedLayerCache pins retrieved layers in memory so the build pass resolves
+// a key to the same layer precompute did, since elimination is irreversible and
+// a stage dropped as cached cannot be rebuilt if a later lookup misses.
+type memoizedLayerCache struct {
+	inner  cache.LayerCache
+	images map[string]v1.Image
+}
+
+func newMemoizedLayerCache(inner cache.LayerCache) *memoizedLayerCache {
+	return &memoizedLayerCache{inner: inner, images: map[string]v1.Image{}}
+}
+
+func (m *memoizedLayerCache) RetrieveLayer(key string) (v1.Image, error) {
+	img, ok := m.images[key]
+	if ok {
+		return img, nil
+	}
+	img, err := m.inner.RetrieveLayer(key)
+	if err != nil {
+		return nil, err
+	}
+	m.images[key] = img
+	return img, nil
+}
+
+func (m *memoizedLayerCache) has(key string) bool {
+	_, ok := m.images[key]
+	return ok
+}
+
+func mergeStageCacheInfo(base *stageCacheInfo, baseCmds []instructions.Command, child *stageCacheInfo) *stageCacheInfo {
+	merged := &stageCacheInfo{}
+	for j, c := range baseCmds {
+		_, isOnbuild := c.(*instructions.OnbuildCommand)
+		if !isOnbuild {
+			merged.redirectKeys = append(merged.redirectKeys, base.redirectKeys[j])
+			merged.redirectHits = append(merged.redirectHits, base.redirectHits[j])
+			merged.cacheKeys = append(merged.cacheKeys, base.cacheKeys[j])
+			merged.cacheHits = append(merged.cacheHits, base.cacheHits[j])
+		}
+	}
+	merged.redirectKeys = append(merged.redirectKeys, child.redirectKeys...)
+	merged.redirectHits = append(merged.redirectHits, child.redirectHits...)
+	merged.cacheKeys = append(merged.cacheKeys, child.cacheKeys...)
+	merged.cacheHits = append(merged.cacheHits, child.cacheHits...)
+	return merged
+}
+
 func commandHash(stage int, cmd string) string {
 	sum := sha256.Sum256([]byte(strconv.Itoa(stage) + "|" + cmd))
 	return hex.EncodeToString(sum[:])
@@ -348,75 +396,73 @@ func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, 
 			continue
 		}
 		if opts.Cache && keyValid {
-			// During precompute (no file context): can't hash COPY --from contents.
+			// mz334: cross-stage copies key off the inferred pointer first, the
+			// source files do not exist during precompute or after elimination.
 			copyCmd, isCopy := commands.CastAbstractCopyCommand(command)
-			if !hasContext && isCopy && copyCmd.From() != "" {
-				inferred := false
-				if config.FF.InferCrossStageCacheKey && opts.CacheCopyLayers && opts.CacheRunLayers {
-					inferredKey, err := populateCompositeKey(command, nil, compositeKey, args, cfg.Env, fileContext, stageFinalCacheKeys, externalImageDigests)
-					if err == nil {
-						inferredCK, err := inferredKey.Hash()
-						if err != nil {
-							return "", ci, v1.Config{}, err
+			crossStageCopy := isCopy && copyCmd.From() != ""
+			inferred := false
+			precomputed := false
+			if crossStageCopy && config.FF.InferCrossStageCacheKey && opts.CacheCopyLayers && opts.CacheRunLayers {
+				inferredKey, err := populateCompositeKey(command, nil, compositeKey.Clone(), args, cfg.Env, fileContext, stageFinalCacheKeys, externalImageDigests)
+				if err == nil {
+					inferredCK, err := inferredKey.Hash()
+					if err != nil {
+						return "", ci, v1.Config{}, err
+					}
+					ci.redirectKeys[i] = inferredCK
+					if memo, ok := layerCache.(*memoizedLayerCache); ok {
+						precomputed = memo.has(inferredCK)
+					}
+					contentKey, err := redirectCacheKey(inferredKey, layerCache)
+					if err != nil {
+						return "", ci, v1.Config{}, err
+					}
+					if contentKey != nil {
+						// a fresh resolution means the source stage is alive, verify
+						// the pointer against the content hash of its files. With
+						// elimination off nothing is dropped, so verify the whole chain.
+						if hasContext && (!precomputed || !config.FF.SkipCachedStages) {
+							files, err := command.FilesUsedFromContext(&cfg, args)
+							if err != nil {
+								return "", ci, v1.Config{}, fmt.Errorf("failed to get files used from context: %w", err)
+							}
+							hashedKey, err := populateCompositeKey(command, files, compositeKey.Clone(), args, cfg.Env, fileContext, nil, nil)
+							if err != nil {
+								return "", ci, v1.Config{}, err
+							}
+							ick, err := contentKey.Hash()
+							if err != nil {
+								return "", ci, v1.Config{}, err
+							}
+							ck, err := hashedKey.Hash()
+							if err != nil {
+								return "", ci, v1.Config{}, err
+							}
+							assert.Assert("executor.compositekey.key-match", ick == ck, "pointer inferred content key %v does not match the computed content key %v", ick, ck)
 						}
-						ci.redirectKeys[i] = inferredCK
-						contentKey, err := redirectCacheKey(inferredKey, layerCache)
-						if err != nil {
-							return "", ci, v1.Config{}, err
-						}
-						if contentKey != nil {
-							compositeKey = *contentKey
-							inferred = true
-							ci.redirectHits[i] = true
-						}
+						compositeKey = *contentKey
+						inferred = true
+						ci.redirectHits[i] = true
+						// mz334: log when the inferred key produced the hit (integration test observability only).
+						logrus.Infof("Cache hit via inferred cross-stage key for cmd: %s", command.String())
 					}
 				}
-				if !inferred {
+			}
+			if !inferred {
+				if crossStageCopy && !hasContext {
+					// Can't hash COPY --from contents without the file context.
 					stopCache = true
 					keyValid = false
 					finalCacheKey = ""
 					continue // COPY is never MetadataOnly, safe to skip
 				}
-			} else {
 				files, err := command.FilesUsedFromContext(&cfg, args)
 				if err != nil {
 					return "", ci, v1.Config{}, fmt.Errorf("failed to get files used from context: %w", err)
 				}
-
-				prevCompositeKey := compositeKey.Clone()
 				compositeKey, err = populateCompositeKey(command, files, compositeKey, args, cfg.Env, fileContext, nil, nil)
 				if err != nil {
 					return "", ci, v1.Config{}, err
-				}
-
-				// mz334: assert the inferred key pointer resolves to the same content key.
-				if config.FF.InferCrossStageCacheKey && opts.CacheCopyLayers && opts.CacheRunLayers {
-					inferredKey, err := populateCompositeKey(command, nil, prevCompositeKey, args, cfg.Env, fileContext, stageFinalCacheKeys, externalImageDigests)
-					if err == nil {
-						inferredCK, err := inferredKey.Hash()
-						if err != nil {
-							return "", ci, v1.Config{}, err
-						}
-						ci.redirectKeys[i] = inferredCK
-						contentKey, err := redirectCacheKey(inferredKey, layerCache)
-						if err != nil {
-							return "", ci, v1.Config{}, err
-						}
-						if contentKey != nil {
-							ick, err := contentKey.Hash()
-							if err != nil {
-								return "", ci, v1.Config{}, err
-							}
-							ck, err := compositeKey.Hash()
-							if err != nil {
-								return "", ci, v1.Config{}, err
-							}
-							assert.Assert("executor.compositekey.key-match", ick == ck, "pointer inferred content key %v does not match the computed content key %v", ick, ck)
-							// mz334: log when the inferred key produced the hit (integration test observability only).
-							logrus.Infof("Cache hit via inferred cross-stage key for cmd: %s", command.String())
-							ci.redirectHits[i] = true
-						}
-					}
 				}
 			}
 
@@ -430,7 +476,9 @@ func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, 
 			finalCacheKey = ck
 			ci.cacheKeys[i] = ck
 
-			if command.ShouldCacheOutput() && !stopCache {
+			// a precompute-resolved copy must apply its cached layer even after
+			// an earlier miss, its source stage may be eliminated
+			if command.ShouldCacheOutput() && (!stopCache || (precomputed && config.FF.SkipCachedStages)) {
 				img, err := layerCache.RetrieveLayer(ck)
 				if err != nil {
 					logrus.Debugf("Failed to retrieve layer: %s", err)
@@ -480,7 +528,7 @@ func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, 
 	return finalCacheKey, ci, cfg, nil
 }
 
-func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOptions, fileContext util.FileContext, snapshotter snapShotter, crossStageDeps bool, stageFinalCacheKeys map[int]string, externalImageDigests map[string]string) error {
+func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOptions, fileContext util.FileContext, snapshotter snapShotter, crossStageDeps bool, stageFinalCacheKeys map[int]string, externalImageDigests map[string]string, layerCache cache.LayerCache) error {
 	assert.Assert("executor.stagebuilder.config-nonnull", s.cf != nil, "stageBuilder (index %d) has nil config file", s.index)
 	// Unpack file system to root if we need to.
 	shouldUnpack := false
@@ -547,27 +595,43 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 
 		cmdTimer = timing.Start("Command")
 
-		// If the command uses files from the context, add them.
-		files, err := command.FilesUsedFromContext(&s.cf.Config, s.args)
-		if err != nil {
-			return fmt.Errorf("failed to get files used from context: %w", err)
-		}
-
+		// mz334: cross-stage copies key off the inferred pointer first, their
+		// source stage may be eliminated and its files never materialize. The
+		// inferred key also serves to push a pointer below.
+		inferred := false
 		var inferredCacheKey string
-		if opts.Cache {
-			prevCompositeKey := compositeKey.Clone()
-			compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, s.cf.Config.Env, fileContext, nil, nil)
-			if err != nil {
-				return err
-			}
-			// mz334: also compute the inferred key so we can push a pointer below.
-			if config.FF.InferCrossStageCacheKey && opts.CacheCopyLayers && opts.CacheRunLayers {
-				inferredKey, err := populateCompositeKey(command, nil, prevCompositeKey, s.args, s.cf.Config.Env, fileContext, stageFinalCacheKeys, externalImageDigests)
+		if opts.Cache && config.FF.InferCrossStageCacheKey && opts.CacheCopyLayers && opts.CacheRunLayers {
+			copyCmd, isCopy := commands.CastAbstractCopyCommand(command)
+			if isCopy && copyCmd.From() != "" {
+				inferredKey, err := populateCompositeKey(command, nil, compositeKey.Clone(), s.args, s.cf.Config.Env, fileContext, stageFinalCacheKeys, externalImageDigests)
 				if err == nil {
 					inferredCacheKey, err = inferredKey.Hash()
 					if err != nil {
 						return err
 					}
+					contentKey, err := redirectCacheKey(inferredKey, layerCache)
+					if err != nil {
+						return err
+					}
+					if contentKey != nil {
+						compositeKey = *contentKey
+						inferred = true
+					}
+				}
+			}
+		}
+		// If the command uses files from the context, add them.
+		var files []string
+		if !inferred {
+			var err error
+			files, err = command.FilesUsedFromContext(&s.cf.Config, s.args)
+			if err != nil {
+				return fmt.Errorf("failed to get files used from context: %w", err)
+			}
+			if opts.Cache {
+				compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, s.cf.Config.Env, fileContext, nil, nil)
+				if err != nil {
+					return err
 				}
 			}
 		}
@@ -638,6 +702,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 				// We continue to handle this case here as users might still have cache entries lying around
 				logrus.Info("No files were changed, appending empty layer to config. No layer added to image.")
 			} else {
+				var err error
 				s.image, err = saveLayerToImage(s.image, layer, command.String(), opts)
 				if err != nil {
 					return fmt.Errorf("failed to save layer: %w", err)
@@ -1146,6 +1211,8 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 
 	stageArgs := make([]*dockerfile.BuildArgs, lastStage.Index+1)
 	cacheInfo := make([]*stageCacheInfo, lastStage.Index+1)
+	stageBuilders := make([]*stageBuilder, lastStage.Index+1)
+	layerCache := newMemoizedLayerCache(NewLayerCache(opts))
 	if opts.Cache && config.FF.CacheLookahead {
 		images := make([]v1.Image, lastStage.Index+1)
 		stageConfigs := make([]v1.Config, lastStage.Index+1)
@@ -1186,7 +1253,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 			if stage.BaseImageStoredLocally {
 				cfg = stageConfigs[stage.BaseImageIndex]
 			}
-			finalCacheKey, ci, resultCfg, err := sb.optimize(compositeKey, cfg, sb.args, opts, fileContext, NewLayerCache(opts), stageFinalCacheKeys, externalImageDigests, false)
+			finalCacheKey, ci, resultCfg, err := sb.optimize(compositeKey, cfg, sb.args, opts, fileContext, layerCache, stageFinalCacheKeys, externalImageDigests, false)
 			if err != nil {
 				return nil, fmt.Errorf("precompute: failed to optimize stage %d: %w", stage.Index, err)
 			}
@@ -1197,7 +1264,70 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 			stageArgs[stage.Index] = sb.args
 			stageConfigs[stage.Index] = resultCfg
 			images[stage.Index] = baseImage
+			stageBuilders[stage.Index] = sb
 		}
+	}
+
+	// rolling cache keys are required, only resumable states keep the keys of
+	// squashed and unsquashed chains identical
+	if opts.Cache && opts.CacheCopyLayers && config.FF.SkipCachedStages && config.FF.CacheLookahead && config.FF.InferCrossStageCacheKey && config.FF.RollingCacheKey {
+		buildTargets := make(map[int]bool)
+		position := make(map[int]int)
+		stagesDependencies := make(map[int]int)
+		copyDependencies := make(map[int]int)
+		for i, s := range kanikoStages {
+			isTarget := slices.ContainsFunc(opts.Target, func(t string) bool { return strings.EqualFold(t, s.Name) })
+			if s.Push || s.Final || isTarget {
+				buildTargets[s.Index] = true
+			}
+			if s.Push {
+				// push stage cannot be squashed
+				stagesDependencies[s.Index] = 1
+			}
+			position[s.Index] = i
+		}
+		for i := len(kanikoStages) - 1; i >= 0; i-- {
+			s := kanikoStages[i]
+			if !buildTargets[s.Index] && stagesDependencies[s.Index] == 0 && copyDependencies[s.Index] == 0 {
+				// counts only grow from later stages, liveness is final here
+				logrus.Infof("Eliminating stage '%v' [idx: '%v'], all consumers are served from cache", s.BaseName, s.Index)
+				continue
+			}
+			if s.BaseImageStoredLocally {
+				stagesDependencies[s.BaseImageIndex]++
+			}
+			for _, c := range stageBuilders[s.Index].cmds {
+				switch cmd := c.(type) {
+				case *commands.CopyCommand:
+					if copyFromIndex, err := strconv.Atoi(cmd.From()); err == nil {
+						copyDependencies[copyFromIndex]++
+					}
+				}
+			}
+		}
+		for i, s := range kanikoStages {
+			if buildTargets[s.Index] || stagesDependencies[s.Index] > 0 || copyDependencies[s.Index] > 0 {
+				if s.BaseImageStoredLocally && stagesDependencies[s.BaseImageIndex] == 1 && copyDependencies[s.BaseImageIndex] == 0 {
+					sb := kanikoStages[position[s.BaseImageIndex]]
+					// squash stages[i] into stages[i].BaseName
+					logrus.Infof("Squashing stages: %s into %s", s.Name, sb.Name)
+					// We squash the base stage into the current stage because,
+					// no one else depends on the base stage so it can be freely moved,
+					// the current stage might depend on other stages so it is not safe to move it.
+					cacheInfo[s.Index] = mergeStageCacheInfo(cacheInfo[sb.Index], sb.Commands, cacheInfo[s.Index])
+					kanikoStages[i] = dockerfile.Squash(sb, s)
+					stagesDependencies[s.BaseImageIndex] = 0
+				}
+			}
+		}
+		var onlyUsedStages []config.KanikoStage
+		for _, s := range kanikoStages {
+			if buildTargets[s.Index] || stagesDependencies[s.Index] > 0 || copyDependencies[s.Index] > 0 {
+				s.SaveStage = stagesDependencies[s.Index] > 0
+				onlyUsedStages = append(onlyUsedStages, s)
+			}
+		}
+		kanikoStages = onlyUsedStages
 	}
 
 	if opts.Dryrun || config.EnvBool("KANIKO_PRINT_PLAN") {
@@ -1297,7 +1427,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 
 		// Apply optimizations to the instructions.
 		precomputedKey := stageFinalCacheKeys[stage.Index]
-		finalCacheKey, buildCi, _, err := sb.optimize(compositeKey, sb.cf.Config, sb.args.Clone(), opts, fileContext, NewLayerCache(opts), stageFinalCacheKeys, externalImageDigests, true)
+		finalCacheKey, buildCi, _, err := sb.optimize(compositeKey, sb.cf.Config, sb.args.Clone(), opts, fileContext, layerCache, stageFinalCacheKeys, externalImageDigests, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to optimize instructions: %w", err)
 		}
@@ -1319,7 +1449,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 
 		stageArgs[stage.Index] = sb.args
 		crossStageDeps := len(crossStageDependencies[stage.Index]) > 0
-		err = sb.build(*compositeKey, opts, fileContext, snapshotter, crossStageDeps, stageFinalCacheKeys, externalImageDigests)
+		err = sb.build(*compositeKey, opts, fileContext, snapshotter, crossStageDeps, stageFinalCacheKeys, externalImageDigests, layerCache)
 		if err != nil {
 			return nil, fmt.Errorf("error building stage: %w", err)
 		}

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -1484,7 +1484,7 @@ RUN foobar
 			if err != nil {
 				t.Errorf("failed to optimize instructions: %v", err)
 			}
-			err = sb.build(*compositeKey, tc.opts, util.FileContext{}, snap, tc.crossStageDeps, nil, nil)
+			err = sb.build(*compositeKey, tc.opts, util.FileContext{}, snap, tc.crossStageDeps, nil, nil, lc)
 			if err != nil {
 				t.Errorf("Expected error to be nil but was %v", err)
 			}


### PR DESCRIPTION
Fixes #334

With the cache lookahead and inferred cross-stage keys in place, a multistage build still built every stage even when all its consumers were served from cache. This PR adds the payoff: after the precompute pass the stage graph optimization from MakeKanikoStages runs again, this time over the precompute stage builders. A COPY --from that resolved via its inferred key is a CachingCopyCommand and no longer counts as a reference, so stages that only fed cached copies get eliminated and newly linear FROM chains get squashed. In the fully warm case a build that forked through COPY --from collapses into a single stage where every layer comes from cache and nothing is unpacked.

Two design points make this safe. First, the composite cache is now recursive: every key is folded into a fixed-size state and the state is the canonical cache key, like OCI chainIDs or git commits. A stage boundary is a resumable digest, so squashed and unsquashed chains produce identical keys by construction and the cache-state-dependent squash cannot change any key. This also fixes the latent separator collision of the joined-text scheme and shrinks the redirect pointer payload to a digest. It busts every existing cache once, which needs a loud release-notes entry. Second, one memoized layer cache is shared between the precompute and the build pass, so every pointer resolution and layer retrieval the precompute made is answered from memory during the build. Nothing is retrieved twice and the build cannot fail on a pointer or layer that vanished in between, which matters because an eliminated stage cannot be rebuilt. The key-match assert stays for resolutions the build pass makes fresh, those copies kept their source stage alive so the files are there to verify against.

The plan renders after the pass, so it shows what will actually be built. dockerfile.go is deliberately untouched apart from exporting Squash, the pass mirrors its loops inline so the two can be merged in a follow-up. This lands as one PR for verification and will be split up for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `FF_KANIKO_SKIP_CACHED_STAGES` to optionally skip building/unpacking cached stages in multi-stage builds when cross-stage `COPY --from` cache keys can be inferred.
* **Bug Fixes**
  * Improved cross-stage cache-key inference and cache hit/redirect hit behavior consistency during stage elimination.
  * Added in-memory memoization to keep cache layers reusable across stage skipping.
* **Tests**
  * Updated golden build plans and cache-key expectations; adjusted test environment to exercise the new flag.
* **Documentation**
  * Documented `FF_KANIKO_SKIP_CACHED_STAGES` (default `false`, enabled-by-default in v1.29.0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->