### PR TITLE
mz896: skip cross-stage infer when run layers are uncached

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz896
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz896
@@ -1,0 +1,14 @@
+# mz896: COPY --from a stage whose RUN layer is not cached (--cache-run-layers=false).
+# Crashes on v1.28.0. The RUN re-runs on the second build and its output changes, but the
+# inferred cross-stage cache key still resolves to the first build's cached copy, so the build
+# panics on the executor.compositekey.key-match assertion instead of taking a cache miss.
+# The uuid is washed out in an empty WORKDIR so both builds produce the same image.
+FROM busybox AS base
+RUN cat /proc/sys/kernel/random/uuid > /u
+
+FROM busybox AS mid
+COPY --from=base /u /u
+WORKDIR /empty
+
+FROM busybox AS final
+COPY --from=mid /empty /empty

--- a/integration/images.go
+++ b/integration/images.go
@@ -189,6 +189,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_target":                     {"--target=second"},
 	"Dockerfile_test_snapshotter_ignorelist":     {"--use-new-run=true", "-v=trace"},
 	"Dockerfile_test_issue_mz334":                {"--cache-copy-layers=true"},
+	"Dockerfile_test_issue_mz896":                {"--cache-copy-layers=true", "--cache-run-layers=false"},
 	"Dockerfile_test_issue_mz787":                {"--cache=true"},
 	"Dockerfile_test_issue_mz789":                {"--cache=true", "--target=final,nosquash"},
 	"Dockerfile_test_cache":                      {"--cache-copy-layers=true"},
@@ -486,6 +487,7 @@ func NewDockerFileBuilder() *DockerFileBuilder {
 		"Dockerfile_test_issue_mz775":   {},
 		"Dockerfile_test_issue_mz782":   {},
 		"Dockerfile_test_issue_mz793":   {},
+		"Dockerfile_test_issue_mz896":   {},
 	}
 	d.TestOCICacheDockerfiles = map[string]struct{}{
 		"Dockerfile_test_cache_oci":         {},

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -336,7 +336,7 @@ func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, 
 			copyCmd, isCopy := commands.CastAbstractCopyCommand(command)
 			if !hasContext && isCopy && copyCmd.From() != "" {
 				inferred := false
-				if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers {
+				if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers && opts.CacheRunLayers {
 					inferredKey, err := populateCompositeKey(command, nil, compositeKey, args, cfg.Env, fileContext, stageFinalCacheKeys, externalImageDigests)
 					if err == nil {
 						inferredCK, err := inferredKey.Hash()
@@ -374,7 +374,7 @@ func (s *stageBuilder) optimize(compositeKeyPtr *CompositeCache, cfg v1.Config, 
 				}
 
 				// mz334: assert the inferred key pointer resolves to the same content key.
-				if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers {
+				if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers && opts.CacheRunLayers {
 					inferredKey, err := populateCompositeKey(command, nil, prevCompositeKey, args, cfg.Env, fileContext, stageFinalCacheKeys, externalImageDigests)
 					if err == nil {
 						inferredCK, err := inferredKey.Hash()
@@ -531,7 +531,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 				return err
 			}
 			// mz334: also compute the inferred key so we can push a pointer below.
-			if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers {
+			if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers && opts.CacheRunLayers {
 				inferredKey, err := populateCompositeKey(command, nil, prevCompositeKey, s.args, s.cf.Config.Env, fileContext, stageFinalCacheKeys, externalImageDigests)
 				if err == nil {
 					inferredCacheKey, err = inferredKey.Hash()


### PR DESCRIPTION
Fixes #896

Cross-stage `COPY --from` inference keys a copy on the source stage's cache key, which is derived from the source's instructions rather than its output. That is only a sound proxy when the source stage is reproducibly cached. With `--cache-run-layers=false` a RUN in the source, or a WORKDIR which shares the run-layer cache flag, re-executes on every build and can emit different content. The inferred pointer then resolves to the first build's cached copy while the second build produces new content, and the build crashes on the `executor.compositekey.key-match` assertion instead of taking a cache miss. This gates the inference on `CacheRunLayers` so an unreproducible source falls back to hashing the actual copied content, which yields a normal cache miss and rebuild.

The gate is deliberately blunt. A source stage can only carry an uncached layer when run layers are uncached, given inference already requires `CacheCopyLayers`, so gating on the global flag is always correct. It is over-broad only for a source that has just cached COPY layers under `--cache-run-layers=false`, a degraded-caching mode already. A precise per-stage materializability predicate is tracked to land with mz334.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cross-stage caching behavior when cached run layers are disabled.
  * Prevented incorrect cache matches that could cause build failures during repeated builds.

* **Tests**
  * Added integration coverage for cross-stage cache handling and cache-warming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->