### PR TITLE
mz879: give runv2 mount commands the build context for cache keys

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz879
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz879
@@ -1,0 +1,6 @@
+# mz879: RUN --mount=type=bind fails on the cache-consume build under --use-new-run.
+# Crashes on v1.28.0. The RunV2 caching command drops the build context, so the mount
+# source resolves to a bare relative path and the second build's cache-key lstat misses
+# with "could not add path: lstat context/foo: no such file or directory".
+FROM alpine
+RUN --mount=type=bind,source=context/foo,target=/mnt/foo cat /mnt/foo > /out

--- a/integration/images.go
+++ b/integration/images.go
@@ -193,6 +193,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_target":                     {"--target=second"},
 	"Dockerfile_test_snapshotter_ignorelist":     {"--use-new-run=true", "-v=trace"},
 	"Dockerfile_test_issue_mz334":                {"--cache-copy-layers=true"},
+	"Dockerfile_test_issue_mz879":                {"--cache-copy-layers=true", "--use-new-run"},
 	"Dockerfile_test_issue_mz896":                {"--cache-copy-layers=true", "--cache-run-layers=false"},
 	"Dockerfile_test_issue_mz787":                {"--cache=true"},
 	"Dockerfile_test_issue_mz789":                {"--cache=true", "--target=final,nosquash"},
@@ -515,6 +516,7 @@ func NewDockerFileBuilder() *DockerFileBuilder {
 		"Dockerfile_test_issue_mz775":   {},
 		"Dockerfile_test_issue_mz782":   {},
 		"Dockerfile_test_issue_mz793":   {},
+		"Dockerfile_test_issue_mz879":   {},
 		"Dockerfile_test_issue_mz896":   {},
 	}
 	d.TestOCICacheDockerfiles = map[string]struct{}{

--- a/pkg/commands/run_marker.go
+++ b/pkg/commands/run_marker.go
@@ -59,6 +59,10 @@ func (r *RunMarkerCommand) String() string {
 	return r.cmd.String()
 }
 
+func (r *RunMarkerCommand) FilesUsedFromContext(config *v1.Config, buildArgs *dockerfile.BuildArgs) ([]string, error) {
+	return runCmdFilesUsedFromContext(config, buildArgs, r.cmd, r.fileContext)
+}
+
 func (r *RunMarkerCommand) FilesToSnapshot() []string {
 	return r.Files
 }
@@ -74,9 +78,10 @@ func (r *RunMarkerCommand) IsArgsEnvsRequiredInCache() bool {
 // CacheCommand returns true since this command should be cached
 func (r *RunMarkerCommand) CacheCommand(img v1.Image) DockerCommand {
 	return &CachingRunCommand{
-		img:       img,
-		cmd:       r.cmd,
-		extractFn: util.ExtractFile,
+		img:         img,
+		cmd:         r.cmd,
+		extractFn:   util.ExtractFile,
+		fileContext: r.fileContext,
 	}
 }
 


### PR DESCRIPTION
Fixes #879

Under `--use-new-run` a `RUN --mount=type=bind` fails on the cache-consume build with `could not add path: lstat <source>: no such file or directory`, while the first build and non-cached builds succeed. The RunV2 command (`RunMarkerCommand`) never resolved the mount source against the build context for cache-key purposes, and its caching variant was constructed without a `fileContext` at all. On the consume build the cached command therefore joined the mount source against an empty root, so the cache-key computation lstat'd a bare relative path and missed.

This brings the RunV2 path to parity with the old RUN path. `RunMarkerCommand` now reports its bind-mount sources through the same `runCmdFilesUsedFromContext` helper as `RunCommand`, resolved against the context root, and `CacheCommand` passes the `fileContext` through to the caching command. The mount source is now part of the cache key consistently across the populate and consume builds, so the cached rebuild succeeds and a changed mount source correctly invalidates the layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cached builds using the new run mode so relative bind-mount source paths are resolved correctly.
  * Prevented cache-key errors when build steps read files mounted from the build context.

* **Tests**
  * Added coverage for builds that use relative context paths with bind mounts and cached layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->