### PR TITLE
add Chris Boot as an individual sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,11 @@ We thank L3montree for their generous support and commitment to open-source sust
 We thank Siemens for their generous support, and especially the team behind [opensource.siemens.com](https://opensource.siemens.com).
 
 ### Individuals
+[<img src="https://github.com/Sped0n.png?size=80" alt="Sped0n" width="80">](https://github.com/Sped0n)
+
 **[Sped0n](https://github.com/Sped0n)**
+
+[<img src="https://github.com/bootc.png?size=80" alt="bootc" width="80">](https://github.com/bootc)
 
 **[bootc](https://github.com/bootc)**
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ We thank Siemens for their generous support, and especially the team behind [ope
 ### Individuals
 **[Sped0n](https://github.com/Sped0n)**
 
+**[Chris Boot](https://github.com/bootc)**
+
 We are grateful for your support.
 
 ## Alternatives

--- a/README.md
+++ b/README.md
@@ -198,13 +198,8 @@ We thank L3montree for their generous support and commitment to open-source sust
 We thank Siemens for their generous support, and especially the team behind [opensource.siemens.com](https://opensource.siemens.com).
 
 ### Individuals
-[<img src="https://github.com/Sped0n.png?size=80" alt="Sped0n" width="80">](https://github.com/Sped0n)
-
-**[Sped0n](https://github.com/Sped0n)**
-
-[<img src="https://github.com/bootc.png?size=80" alt="bootc" width="80">](https://github.com/bootc)
-
-**[bootc](https://github.com/bootc)**
+<a href="https://github.com/Sped0n"><img src="https://github.com/Sped0n.png?size=80" width="80" alt="Sped0n" title="Sped0n"></a>
+<a href="https://github.com/bootc"><img src="https://github.com/bootc.png?size=80" width="80" alt="bootc" title="bootc"></a>
 
 We are grateful for your support.
 

--- a/README.md
+++ b/README.md
@@ -198,8 +198,9 @@ We thank L3montree for their generous support and commitment to open-source sust
 We thank Siemens for their generous support, and especially the team behind [opensource.siemens.com](https://opensource.siemens.com).
 
 ### Individuals
-<a href="https://github.com/Sped0n"><img src="https://github.com/Sped0n.png?size=80" width="80" alt="Sped0n" title="Sped0n"></a>
-<a href="https://github.com/bootc"><img src="https://github.com/bootc.png?size=80" width="80" alt="bootc" title="bootc"></a>
+| [<img src="https://github.com/Sped0n.png?size=80" width="80" alt="Sped0n">](https://github.com/Sped0n) | [<img src="https://github.com/bootc.png?size=80" width="80" alt="bootc">](https://github.com/bootc) |
+|:--:|:--:|
+| **[Sped0n](https://github.com/Sped0n)** | **[bootc](https://github.com/bootc)** |
 
 We are grateful for your support.
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ We thank Siemens for their generous support, and especially the team behind [ope
 ### Individuals
 **[Sped0n](https://github.com/Sped0n)**
 
-**[Chris Boot](https://github.com/bootc)**
+**[bootc](https://github.com/bootc)**
 
 We are grateful for your support.
 

--- a/README.md
+++ b/README.md
@@ -198,9 +198,12 @@ We thank L3montree for their generous support and commitment to open-source sust
 We thank Siemens for their generous support, and especially the team behind [opensource.siemens.com](https://opensource.siemens.com).
 
 ### Individuals
-| [<img src="https://github.com/Sped0n.png?size=80" width="80" alt="Sped0n">](https://github.com/Sped0n) | [<img src="https://github.com/bootc.png?size=80" width="80" alt="bootc">](https://github.com/bootc) |
-|:--:|:--:|
-| **[Sped0n](https://github.com/Sped0n)** | **[bootc](https://github.com/bootc)** |
+<table>
+<tr>
+<td align="center"><a href="https://github.com/Sped0n"><img src="https://github.com/Sped0n.png?size=80" width="80" alt="Sped0n"><br><sub><b>Sped0n</b></sub></a></td>
+<td align="center"><a href="https://github.com/bootc"><img src="https://github.com/bootc.png?size=80" width="80" alt="bootc"><br><sub><b>bootc</b></sub></a></td>
+</tr>
+</table>
 
 We are grateful for your support.
 


### PR DESCRIPTION
Chris Boot ([bootc](https://github.com/bootc)) has become an individual sponsor of the project. This adds them to the Individuals section of the sponsorships list in the README, following the same format as the existing entries.

Again, thank you very much 🙇