### PR TITLE
address review follow-ups from the feature-flag PR

### DIFF
--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -120,13 +120,13 @@ func TestRun(t *testing.T) {
 					dockerfilePath := filepath.Join(testDir, testSuite.Dockerfile)
 					for _, test := range testSuite.Tests {
 						t.Run(renderCommand(test.Env, test.Args), func(t *testing.T) {
+							t.Cleanup(config.InitFeatureFlags)
 							for k, v := range test.Env {
 								t.Setenv(k, v)
 							}
 							// Feature flags resolve once at startup; re-resolve so
 							// this subtest's env takes effect, and restore afterwards.
 							config.InitFeatureFlags()
-							t.Cleanup(config.InitFeatureFlags)
 
 							opts := config.KanikoOptions{}
 							origNewLayerCache := executor.NewLayerCache

--- a/pkg/commands/cmd.go
+++ b/pkg/commands/cmd.go
@@ -44,7 +44,7 @@ func (c *CmdCommand) ExecuteCommand(config *v1.Config, _ *dockerfile.BuildArgs) 
 		}
 
 		newCommand = append(shell, strings.Join(c.cmd.CmdLine, " "))
-		assert.Assert("cmd.command-nonempty", len(newCommand) > 0, "CMD shell form produced an empty command")
+		assert.Assert("cmd.command-nonempty", strings.TrimSpace(strings.Join(c.cmd.CmdLine, " ")) != "", "CMD shell form produced an empty command")
 	} else {
 		newCommand = c.cmd.CmdLine
 	}

--- a/pkg/commands/expose.go
+++ b/pkg/commands/expose.go
@@ -54,7 +54,9 @@ func (r *ExposeCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.
 			p = p + "/tcp"
 		}
 		parts := strings.Split(p, "/")
-		assert.Assert("expose.parts-count", len(parts) >= 2, "port string must contain '/' after normalization")
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid exposed port: %s", p)
+		}
 		protocol := parts[1]
 		if !validProtocol(protocol) {
 			return fmt.Errorf("invalid protocol: %s", protocol)

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -1363,8 +1363,9 @@ func Test_correctDockerignoreFileIsUsed(t *testing.T) {
 }
 
 func Test_ExcludesFile_AbsoluteOutsideBuildContext(t *testing.T) {
+	previous := config.FF.ScopedDockerignore
 	config.FF.ScopedDockerignore = true
-	t.Cleanup(func() { config.FF.ScopedDockerignore = false })
+	t.Cleanup(func() { config.FF.ScopedDockerignore = previous })
 	tempDir := t.TempDir()
 
 	// dockerignore, allowlist style

--- a/pkg/util/transport_util.go
+++ b/pkg/util/transport_util.go
@@ -106,8 +106,12 @@ func MakeTransport(opts config.RegistryOptions, registryName string) (http.Round
 	}
 
 	if config.FF.DisableHTTP2 {
-		tr.(*http.Transport).ForceAttemptHTTP2 = false
-		tr.(*http.Transport).TLSClientConfig.NextProtos = []string{"http/1.1"}
+		t := tr.(*http.Transport)
+		t.ForceAttemptHTTP2 = false
+		if t.TLSClientConfig == nil {
+			t.TLSClientConfig = &tls.Config{}
+		}
+		t.TLSClientConfig.NextProtos = []string{"http/1.1"}
 	}
 
 	return tr, nil


### PR DESCRIPTION
Follow-up fixes surfaced while reviewing the feature-flag registry PR, split out so that one stays focused on the registry itself.

Guards a nil TLSClientConfig before disabling HTTP/2, since the cloned default transport leaves it nil on the common path and --disable-http2 would otherwise panic. Tightens EXPOSE port parsing to reject values with more than one slash instead of silently reading the second component. Checks the actual CMD shell-form command for emptiness rather than the always-populated wrapper slice. Restores the prior feature-flag value in two tests instead of forcing it off, so they no longer leak state into later tests.

Based on mz852-feature-flag-table; will retarget to main once that merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for empty shell-form commands.
  * Invalid exposed port formats now return clear errors.
  * Prevented potential transport configuration failures when HTTP/2 is disabled.
  * Improved feature-flag handling across isolated test environments.
  * Preserved existing configuration values during test cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->