### PR TITLE
limit integration test parallelism to 8

### DIFF
--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -48,6 +48,7 @@ make out/warmer
 
 FLAGS=(
   "--timeout=50m"
+  "-parallel=${TEST_PARALLELISM:-8}"
 )
 
 if [[ -n ${DOCKERFILE_PATTERN} ]]; then


### PR DESCRIPTION
Cap the integration suite at 8 parallel tests (overridable via TEST_PARALLELISM). Highly parallel runners overload the shared docker daemon, so concurrent diffoci `docker save --platform` calls intermittently fail with "does not provide the specified platform" on a random busybox test. Capping concurrency keeps the daemon stable. Applies to local runs too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Integration tests now run with configurable parallelism.
  * Uses the `TEST_PARALLELISM` setting when provided, with a default of 8 concurrent test processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->