### PR TITLE
pull diffoci images with an explicit platform

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1632,11 +1632,11 @@ func TestCustomPlatformVariant(t *testing.T) {
 
 func diffoci(t *testing.T, image1, image2, platform string, flags ...string) *exec.Cmd {
 	// workaround for container-diff OCI issue https://github.com/GoogleContainerTools/container-diff/issues/389
-	pullArgs := []string{"pull"}
-	if platform != "" {
-		pullArgs = append(pullArgs, "--platform="+platform)
-		flags = append(flags, "--platform="+platform)
+	if platform == "" {
+		platform = "linux/" + runtime.GOARCH
 	}
+	pullArgs := []string{"pull", "--platform=" + platform}
+	flags = append(flags, "--platform="+platform)
 	out := RunCommand(exec.Command("docker", append(pullArgs, image1)...), t)
 	t.Logf("docker pull cmd output for image1 = %s", string(out))
 	image1 = daemonPrefix + image1


### PR DESCRIPTION
The integration suite intermittently fails a random image comparison with "does not provide the specified platform / unrecognized image format" from diffoci's internal `docker save --platform linux/amd64`. The harness pre-pulls each image into the daemon without a platform for non-cross-compile tests, which can leave a platform-ambiguous entry in the containerd image store. Pulling with an explicit `--platform` materializes a concrete single-platform image so the save resolves it deterministically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image comparisons now consistently use an explicit Docker platform.
  * When no platform is provided, the system defaults to the current architecture on Linux.
  * Platform selection is applied consistently during image retrieval and comparison, improving results across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->