### PR TITLE
pin system containerd to v2.2.5 in integration CI

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -51,6 +51,24 @@ jobs:
         with:
           persist-credentials: false
 
+      # ubuntu-24.04 ships containerd v2.2.6, which regressed docker save --platform
+      # so it intermittently fails on valid single-platform images and flakes the
+      # integration suite (diffoci image load). dockerd runs against this system
+      # containerd, so pin it to v2.2.5 before docker starts. See docker/cli#6457.
+      - name: pin system containerd to v2.2.5
+        run: |
+          set -eux
+          curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-29.6.1.tgz -o /tmp/docker.tgz
+          tar xzf /tmp/docker.tgz -C /tmp
+          /tmp/docker/containerd --version
+          BIN=$(command -v containerd)
+          sudo systemctl stop containerd
+          sudo install -m0755 /tmp/docker/containerd "$BIN"
+          sudo install -m0755 /tmp/docker/containerd-shim-runc-v2 "$(dirname "$BIN")/containerd-shim-runc-v2"
+          sudo systemctl start containerd
+          sleep 3
+          containerd --version
+
       - uses: docker/setup-docker-action@6d7cfa65f60a9dda7b46e5513fa982536f3c9877 # v5.3.0
         with:
           version: 29.5.2


### PR DESCRIPTION
The ubuntu-24.04 runner ships containerd v2.2.6, which regressed `docker save --platform` so it intermittently fails on valid single-platform images with "does not provide the specified platform". dockerd runs against this system containerd (setup-docker-action only restarts docker, never containerd), so the integration suite flakes whenever diffoci loads an image, on main and every PR. Pinning the system containerd back to v2.2.5 (from docker's 29.6.1 static bundle) before docker starts makes the suite deterministic again. Remove this step once the upstream regression (docker/cli#6457) is fixed on the runner image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration test infrastructure to use a pinned container runtime version.
  * Improved consistency and reliability of Docker and k3s-based integration test runs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->