### PR TITLE
Document feature flag profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `--image-fs-extract-retry`](#flag---image-fs-extract-retry)
       - [Flag `--image-download-retry`](#flag---image-download-retry)
     - [Feature Flags](#feature-flags)
+      - [Profiles](#profiles)
       - [Flag `FF_KANIKO_COPY_AS_ROOT`](#flag-ff_kaniko_copy_as_root)
       - [Flag `FF_KANIKO_IGNORE_CACHED_MANIFEST`](#flag-ff_kaniko_ignore_cached_manifest)
       - [Flag `FF_KANIKO_RUN_MOUNT_BIND`](#flag-ff_kaniko_run_mount_bind)
@@ -1139,6 +1140,39 @@ remote image. Consecutive retries occur with exponential backoff and an initial
 delay of 1 second. Defaults to `0`.
 
 ### Feature Flags
+
+#### Profiles
+
+##### Preview
+
+These flags include fixes and improvements that are scheduled to become default. Opting into the Preview profile gives you early access to upcoming performance improvements, bugfixes and features. While these flags are tested and ready to use, implementation details may still change.
+
+```sh
+FF_KANIKO_EXPAND_HEREDOC=true
+FF_KANIKO_HASH_DIR_FRAMING=true
+FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY=true
+FF_KANIKO_PRECOMPILE_DOCKERIGNORE=true
+FF_KANIKO_REPRODUCIBLE_PRESERVE_BASE_LAYERS=true
+FF_KANIKO_RESOLVE_CACHE_KEY=true
+FF_KANIKO_ROLLING_CACHE_KEY=true
+FF_KANIKO_RUN_HONOR_GROUP=true
+FF_KANIKO_RUN_VIA_TINI=true
+FF_KANIKO_SKIP_RELABEL_RECOMPRESS=true
+FF_KANIKO_SKIP_WRITE_WHITEOUTS=true
+FF_KANIKO_UNTAR_SKIP_ROOT=true
+```
+
+##### BuildKit compatibility
+
+In a few places, Kaniko keeps its historical, non-compliant behavior instead of following the Dockerfile specification. Switching to the compliant implementation by default would require users with large codebases to update their Dockerfiles, making migration to our fork tedious. These flags enable the spec-compliant behavior, matching BuildKit one-to-one. This profile is used in our integration tests.
+
+```sh
+FF_KANIKO_COPY_AS_ROOT=true
+FF_KANIKO_COPY_CHMOD_ON_IMPLICIT_DIRS=true
+FF_KANIKO_EXPAND_HEREDOC=true
+FF_KANIKO_RUN_HONOR_GROUP=true
+FF_KANIKO_UNTAR_SKIP_ROOT=true
+```
 
 #### Flag `FF_KANIKO_COPY_AS_ROOT`
 

--- a/README.md
+++ b/README.md
@@ -1145,7 +1145,7 @@ delay of 1 second. Defaults to `0`.
 
 ##### Preview
 
-These flags include fixes and improvements that are scheduled to become default. Opting into the Preview profile gives you early access to upcoming performance improvements, bugfixes and features. While these flags are tested and ready to use, implementation details may still change.
+Opting into the Preview profile gives you early access to upcoming performance improvements, bugfixes and features. While these flags are tested and ready to use, implementation details may still change.
 
 ```sh
 FF_KANIKO_EXPAND_HEREDOC=true

--- a/README.md
+++ b/README.md
@@ -1164,7 +1164,7 @@ FF_KANIKO_UNTAR_SKIP_ROOT=true
 
 ##### BuildKit compatibility
 
-In a few places, Kaniko keeps its historical, non-compliant behavior instead of following the Dockerfile specification. Switching to the compliant implementation by default would require users with large codebases to update their Dockerfiles, making migration to our fork tedious. These flags enable the spec-compliant behavior, matching BuildKit one-to-one. This profile is used in our integration tests.
+In a few places, Kaniko keeps its historical, non-compliant behavior instead of following the Dockerfile specification. Switching to the compliant implementation by default would require users with large codebases to update their Dockerfiles, making migration to our fork tedious. These flags enable the spec-compliant behavior, matching BuildKit one-to-one. Our integration tests run this profile on top of Preview.
 
 ```sh
 FF_KANIKO_COPY_AS_ROOT=true

--- a/integration/images.go
+++ b/integration/images.go
@@ -96,8 +96,7 @@ var envsMap = map[string][]string{
 	"Dockerfile_test_arg_secret":  {"SSH_PRIVATE_KEY=ThEPriv4t3Key"},
 	"Dockerfile_test_issue_519":   {"DOCKER_BUILDKIT=0"},
 	"Dockerfile_test_issue_cg188": {"SECRET=blubb"},
-	"Dockerfile_test_issue_mz774": {"FF_KANIKO_SKIP_WRITE_WHITEOUTS=1"},
-	"Dockerfile_test_issue_mz775": {"FF_KANIKO_CACHE_LOOKAHEAD=0", "FF_KANIKO_SKIP_RELABEL_RECOMPRESS=1"},
+	"Dockerfile_test_issue_mz775": {"FF_KANIKO_CACHE_LOOKAHEAD=0"},
 	"Dockerfile_test_issue_mz793": {"FF_KANIKO_VOLUME_SKIP_MKDIR=0"},
 	"Dockerfile_test_issue_mz473": {"KANIKO_DIR=/kaniko2"},
 	"Dockerfile_test_issue_mz661": {"KANIKO_DIR=/kaniko2"},
@@ -121,6 +120,8 @@ var KanikoEnv = []string{
 	"FF_KANIKO_RUN_HONOR_GROUP=1",
 	"FF_KANIKO_PRECOMPILE_DOCKERIGNORE=1",
 	"FF_KANIKO_EXPAND_HEREDOC=1",
+	"FF_KANIKO_SKIP_WRITE_WHITEOUTS=1",
+	"FF_KANIKO_SKIP_RELABEL_RECOMPRESS=1",
 	"KANIKO_PRINT_PLAN=1",
 }
 


### PR DESCRIPTION
Group the growing set of FF_KANIKO_* feature flags into two named profiles in the README so users have a clear entry point instead of reading each flag one at a time. Preview bundles the flags we plan to make default in a future release, letting users opt into the fixes and improvements early. BuildKit compatibility bundles the flags that force spec-compliant behavior where kaniko otherwise stays backward compatible, matching BuildKit for users who want parity. Documentation only, no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Feature Flags documentation to add a new **“Profiles”** section, including **“Preview”** and **“BuildKit compatibility”** profiles with their feature-flag descriptions and related testing notes.
* **Tests**
  * Updated the integration test suite’s Kaniko feature-flag configuration so the intended flags are applied consistently across Kaniko executor/container runs, while preserving the correct per-Dockerfile overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->