### PR TITLE
tracing: nest per-command spans, drop cache-hit source-image spans

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -675,7 +675,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 		if !initSnapshotTaken && !isCacheCommand && !command.ProvidesFilesToSnapshot() {
 			// Take initial snapshot if command does not expect to return
 			// a list of files.
-			t := timing.Start("Initial FS snapshot")
+			t := timing.StartChild(cmdTimer, "Initial FS snapshot")
 			err := snapshotter.Init()
 			t.End()
 			if err != nil {
@@ -684,7 +684,10 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 			initSnapshotTaken = true
 		}
 
-		if err := command.ExecuteCommand(&s.cf.Config, s.args); err != nil {
+		execTimer := timing.StartChild(cmdTimer, "Execute")
+		err := command.ExecuteCommand(&s.cf.Config, s.args)
+		execTimer.End()
+		if err != nil {
 			return fmt.Errorf("failed to execute command: %w", err)
 		}
 		files = command.FilesToSnapshot()

--- a/pkg/image/image_util.go
+++ b/pkg/image/image_util.go
@@ -60,8 +60,6 @@ func RetrieveSourceImage(stage config.KanikoStage, opts *config.KanikoOptions) (
 }
 
 func RetrieveSourceImageInternal(baseName string, baseImageStoredLocally bool, baseImageIndex int, metaArgs []instructions.ArgCommand, opts *config.KanikoOptions) (v1.Image, error) {
-	t := timing.Start("Retrieving Source Image")
-	defer t.End()
 	var buildArgs []string
 
 	for _, marg := range metaArgs {
@@ -104,6 +102,8 @@ func RetrieveSourceImageInternal(baseName string, baseImageStoredLocally bool, b
 	}
 
 	// Otherwise, initialize image as usual
+	t := timing.Start("Retrieving Source Image")
+	defer t.End()
 	return RetrieveRemoteImage(currentBaseName, opts.RegistryOptions, opts.CustomPlatform)
 }
 

--- a/pkg/timing/timing.go
+++ b/pkg/timing/timing.go
@@ -67,13 +67,28 @@ func phaseFor(category string) string {
 	return "kaniko"
 }
 
-// Start begins a span for category, or a noop span when the category is not traced.
+// Start begins a span for category off the root build span, or a noop span when
+// the category is not traced.
 func Start(category string) trace.Span {
+	return start(nil, category)
+}
+
+// StartChild begins a span for category nested under parent, so a sub-step of a
+// traced operation shows as a child instead of an overlapping sibling. Safe when
+// parent is nil or tracing is off.
+func StartChild(parent trace.Span, category string) trace.Span {
+	return start(parent, category)
+}
+
+func start(parent trace.Span, category string) trace.Span {
 	tracerMu.Lock()
 	tr, ctx := tracer, parentCtx
 	tracerMu.Unlock()
 	if tr == nil || noSpanCategories[category] {
 		return noop.Span{}
+	}
+	if parent != nil && parent.SpanContext().IsValid() {
+		ctx = trace.ContextWithSpan(ctx, parent)
 	}
 	_, span := tr.Start(ctx, category)
 	span.SetAttributes(attribute.String("kaniko.phase", phaseFor(category)))

--- a/pkg/timing/timing.go
+++ b/pkg/timing/timing.go
@@ -67,15 +67,12 @@ func phaseFor(category string) string {
 	return "kaniko"
 }
 
-// Start begins a span for category off the root build span, or a noop span when
-// the category is not traced.
+// Start begins a span for category, or a noop span when the category is not traced.
 func Start(category string) trace.Span {
 	return start(nil, category)
 }
 
-// StartChild begins a span for category nested under parent, so a sub-step of a
-// traced operation shows as a child instead of an overlapping sibling. Safe when
-// parent is nil or tracing is off.
+// StartChild begins a span for category nested under parent.
 func StartChild(parent trace.Span, category string) trace.Span {
 	return start(parent, category)
 }


### PR DESCRIPTION
Kaniko's build traces come out flat: `pkg/timing` parents every span to the root `build` span and throws away the child context, so operations that are nested in time render as overlapping siblings. The clearest symptom is the per-command initial FS snapshot appearing to run in parallel with the command it belongs to, which is impossible. This threads context through `pkg/timing` so a `Timer` can spawn child spans, gives command execution its own span, and hangs both the initial snapshot and the execute span under the command span. A command now reads as a parent bar with its sub-steps nested sequentially inside instead of a pile of overlapping bars.

Stacked on `mz-otel-instrumentation`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved execution timing and tracing for build commands and remote source-image retrieval.
  * Timing data now more accurately reflects active remote operations and nested command activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->