### PR TITLE
add integration tests for --image-format layer relabeling

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz849_dockerv2
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz849_dockerv2
@@ -1,0 +1,6 @@
+# mz849: --image-format=docker relabels an OCI base image's layers to docker schema2.
+# busybox:latest is an OCI base, its layers are application/vnd.oci.image.layer.v1.tar+gzip.
+# With --image-format=docker kaniko must rewrite those base layers to
+# application/vnd.docker.image.rootfs.diff.tar.gzip in the pushed image.
+FROM busybox
+COPY context/foo /foo

--- a/integration/dockerfiles/Dockerfile_test_issue_mz849_ociv1
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz849_ociv1
@@ -1,0 +1,7 @@
+# mz849: --image-format=oci relabels a docker schema2 base image's layers to OCI.
+# busybox:1.31 is a docker schema2 base, its layers are
+# application/vnd.docker.image.rootfs.diff.tar.gzip.
+# With --image-format=oci kaniko must rewrite those base layers to
+# application/vnd.oci.image.layer.v1.tar+gzip in the pushed image.
+FROM busybox:1.31
+COPY context/foo /foo

--- a/integration/images.go
+++ b/integration/images.go
@@ -136,6 +136,7 @@ var additionalDockerFlagsMap = map[string][]string{
 	// provenance forces ociv1 on buildkit but for these images we emit dockerv2 in kaniko
 	"Dockerfile_test_cross_compile":                {"--platform=linux/" + crossCompileArch},
 	"Dockerfile_test_issue_mz849":                  {"--provenance=false"},
+	"Dockerfile_test_issue_mz849_dockerv2":         {"--provenance=false"},
 	"Dockerfile_test_snapshotter_ignorelist":       {"--provenance=false"},
 	"Dockerfile_test_whitelist":                    {"--provenance=false"},
 	"Dockerfile_test_volume_4":                     {"--provenance=false"},
@@ -179,6 +180,8 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_issue_mz824":                {"--cache=true"},
 	"Dockerfile_test_issue_519":                  {"--target=final_stage,nosquash1,nosquash2"},
 	"Dockerfile_test_issue_mz849":                {"--image-format=docker"},
+	"Dockerfile_test_issue_mz849_dockerv2":       {"--image-format=docker"},
+	"Dockerfile_test_issue_mz849_ociv1":          {"--image-format=oci"},
 	"Dockerfile_test_multistage_args_issue_1911": {"--target=base-custom2,nosquash1,nosquash2,nosquash3"},
 	"Dockerfile_test_cmd":                        {"--target=final,nosquash"},
 	"Dockerfile_test_issue_mz247":                {"--target=final,nosquash"},


### PR DESCRIPTION
The --image-format flag added in mz849 relabels a base image's layer media types when the requested output format differs from the base, but the only existing coverage (Dockerfile_test_issue_mz849) builds FROM scratch, which has no layers, so the layer relabel route in pkg/image/transform.go never ran end to end in either direction. These two tests close that gap by picking bases whose on-registry format is known: busybox:latest is OCI and busybox:1.31 is docker schema2. Building the OCI base with --image-format=docker exercises the OCI to docker layer rewrite, the docker base with --image-format=oci exercises the reverse, and both are diffed against a docker build of the same format so the resulting media types are verified, not just executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for Docker and OCI image output formats.
  * Added validation for converting image layers between OCI and Docker-compatible formats.
  * Included scenarios covering image provenance settings during Docker builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->