### PR TITLE
mz936: read COPY --from images through the shared base store

### DIFF
--- a/golden/testdata/test_issue_mz936/Dockerfile
+++ b/golden/testdata/test_issue_mz936/Dockerfile
@@ -16,6 +16,10 @@ FROM base AS derived
 FROM alpine@sha256:451eee8bedcb2f029756dc3e9d73bab0e7943c1ac55cff3a4861c52a0fdd3e98 AS unused
 RUN touch /blubb
 
+# extshared stores as the image is also read by a COPY --from below
+FROM alpine:3.13 AS extshared
+RUN touch /blubb
+
 # final stores iff it gets pushed
 FROM debian@sha256:264982ff4d18000fa74540837e2c43ca5137a53a83f8f62c7b3803c0f0bdcd56 AS final
 COPY --from=base /blubb /0
@@ -23,3 +27,7 @@ COPY --from=shared1 /blubb /1
 COPY --from=shared2 /blubb /2
 COPY --from=unused /blubb /3
 COPY --from=derived /blubb /4
+COPY --from=extshared /blubb /5
+COPY --from=alpine:3.13 /etc/os-release /6
+# streams, nothing else reads it
+COPY --from=debian:10.13 /etc/os-release /7

--- a/golden/testdata/test_issue_mz936/plans/push
+++ b/golden/testdata/test_issue_mz936/plans/push
@@ -1,3 +1,6 @@
+FETCH alpine:3.13
+UNPACK alpine:3.13 /kaniko/deps/alpine:3.13
+STREAM debian:10.13 /kaniko/deps/debian:10.13
 FROM alpine@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69 AS base
   FETCH alpine@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69
   UNPACK alpine@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69
@@ -31,6 +34,13 @@ RUN touch /blubb
 SAVE FILES [/blubb] /kaniko/deps/4
 CLEAN
 
+FROM alpine:3.13 AS extshared
+  FETCH alpine:3.13
+  UNPACK alpine:3.13
+RUN touch /blubb
+SAVE FILES [/blubb] /kaniko/deps/5
+CLEAN
+
 FROM debian@sha256:264982ff4d18000fa74540837e2c43ca5137a53a83f8f62c7b3803c0f0bdcd56 AS final
   FETCH debian@sha256:264982ff4d18000fa74540837e2c43ca5137a53a83f8f62c7b3803c0f0bdcd56
   UNPACK debian@sha256:264982ff4d18000fa74540837e2c43ca5137a53a83f8f62c7b3803c0f0bdcd56
@@ -39,6 +49,9 @@ COPY --from=shared1 /blubb /1
 COPY --from=shared2 /blubb /2
 COPY --from=unused /blubb /3
 COPY --from=derived /blubb /4
+COPY --from=extshared /blubb /5
+COPY --from=alpine:3.13 /etc/os-release /6
+COPY --from=debian:10.13 /etc/os-release /7
 PUSH [example.com/img:latest]
   UPLOAD sha256:cf05a52c02353f0b2b6f9be0549ac916c3fb1dc8d4bacd405eac7f28562ec9f2
   UPLOAD COPY --from=base /blubb /0
@@ -46,3 +59,6 @@ PUSH [example.com/img:latest]
   UPLOAD COPY --from=shared2 /blubb /2
   UPLOAD COPY --from=unused /blubb /3
   UPLOAD COPY --from=derived /blubb /4
+  UPLOAD COPY --from=extshared /blubb /5
+  UPLOAD COPY --from=alpine:3.13 /etc/os-release /6
+  UPLOAD COPY --from=debian:10.13 /etc/os-release /7

--- a/golden/testdata/test_issue_mz936/plans/shared
+++ b/golden/testdata/test_issue_mz936/plans/shared
@@ -1,3 +1,6 @@
+FETCH alpine:3.13
+UNPACK alpine:3.13 /kaniko/deps/alpine:3.13
+STREAM debian:10.13 /kaniko/deps/debian:10.13
 FROM alpine@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69 AS base
   FETCH alpine@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69
   UNPACK alpine@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69
@@ -31,6 +34,13 @@ RUN touch /blubb
 SAVE FILES [/blubb] /kaniko/deps/4
 CLEAN
 
+FROM alpine:3.13 AS extshared
+  FETCH alpine:3.13
+  UNPACK alpine:3.13
+RUN touch /blubb
+SAVE FILES [/blubb] /kaniko/deps/5
+CLEAN
+
 FROM debian@sha256:264982ff4d18000fa74540837e2c43ca5137a53a83f8f62c7b3803c0f0bdcd56 AS final
   STREAM debian@sha256:264982ff4d18000fa74540837e2c43ca5137a53a83f8f62c7b3803c0f0bdcd56
 COPY --from=base /blubb /0
@@ -38,3 +48,6 @@ COPY --from=shared1 /blubb /1
 COPY --from=shared2 /blubb /2
 COPY --from=unused /blubb /3
 COPY --from=derived /blubb /4
+COPY --from=extshared /blubb /5
+COPY --from=alpine:3.13 /etc/os-release /6
+COPY --from=debian:10.13 /etc/os-release /7

--- a/golden/testdata/test_issue_mz936/plans/streamed
+++ b/golden/testdata/test_issue_mz936/plans/streamed
@@ -1,3 +1,5 @@
+STREAM alpine:3.13 /kaniko/deps/alpine:3.13
+STREAM debian:10.13 /kaniko/deps/debian:10.13
 FROM alpine@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69 AS base
   STREAM alpine@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69
 RUN touch /blubb
@@ -28,6 +30,12 @@ RUN touch /blubb
 SAVE FILES [/blubb] /kaniko/deps/4
 CLEAN
 
+FROM alpine:3.13 AS extshared
+  STREAM alpine:3.13
+RUN touch /blubb
+SAVE FILES [/blubb] /kaniko/deps/5
+CLEAN
+
 FROM debian@sha256:264982ff4d18000fa74540837e2c43ca5137a53a83f8f62c7b3803c0f0bdcd56 AS final
   STREAM debian@sha256:264982ff4d18000fa74540837e2c43ca5137a53a83f8f62c7b3803c0f0bdcd56
 COPY --from=base /blubb /0
@@ -35,3 +43,6 @@ COPY --from=shared1 /blubb /1
 COPY --from=shared2 /blubb /2
 COPY --from=unused /blubb /3
 COPY --from=derived /blubb /4
+COPY --from=extshared /blubb /5
+COPY --from=alpine:3.13 /etc/os-release /6
+COPY --from=debian:10.13 /etc/os-release /7

--- a/golden/testdata/test_issue_mz936/test.go
+++ b/golden/testdata/test_issue_mz936/test.go
@@ -6,7 +6,9 @@ import "github.com/osscontainertools/kaniko/golden/types"
 // FF_KANIKO_SHARED_BASE_CACHE. A base pulled by several stages is downloaded once
 // (first stage stores it, the rest load it), a base persisted for a downstream
 // stage is stored, and on a push the final stage's base is stored because the
-// push re-reads its layers to upload them.
+// push re-reads its layers to upload them. A COPY --from=<image> counts as a
+// read too, so an image read both as a base and by a COPY --from is stored
+// once, while an image only a COPY --from reads streams into the deps dir.
 var Tests = types.GoldenTests{
 	Name:       "test_issue_mz936",
 	Dockerfile: "Dockerfile",

--- a/golden/testdata/test_unittests/plans/two_copyfrom_and_arg_final
+++ b/golden/testdata/test_unittests/plans/two_copyfrom_and_arg_final
@@ -1,3 +1,4 @@
+STREAM debian:10.13 /kaniko/deps/debian:10.13
 FROM debian:12.10 AS base
   STREAM debian:12.10
 COPY . .

--- a/pkg/config/stage.go
+++ b/pkg/config/stage.go
@@ -27,7 +27,6 @@ type KanikoStage struct {
 	Commands               []instructions.Command
 	BaseImageIndex         int
 	BaseImageDigest        string
-	BaseImageShared        bool
 	Push                   bool
 	Final                  bool
 	BaseImageStoredLocally bool

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -411,34 +411,6 @@ func MakeKanikoStages(opts *config.KanikoOptions, stages []instructions.Stage, m
 			onlyUsedStages = append(onlyUsedStages, s)
 		}
 	}
-	// legacy warmer overrides images override digest method to not return the digest
-	// as they get stored in a tarball and digest is lost in the process.
-	// But this also means that our defensive store and load here can't play nicely with them.
-	legacyCache := !config.FF.OCIWarmer && opts.Cache && opts.CacheDir != ""
-	if config.FF.SharedBaseCache && !legacyCache {
-		writesOutput := (!opts.NoPush && len(opts.Destinations) > 0) || opts.TarPath != "" || opts.OCILayoutPath != ""
-		for i := range onlyUsedStages {
-			s := &onlyUsedStages[i]
-			if s.BaseImageStoredLocally || s.BaseImageDigest == "" || s.BaseImageShared {
-				continue
-			}
-			// A base re-read on push/save is stored so the re-read hits the local copy.
-			if (s.SaveStage && !s.Final) || (s.Push && writesOutput) {
-				s.BaseImageShared = true
-			}
-			// A base pulled by several stages is stored once and reused by the rest.
-			for j := i + 1; j < len(onlyUsedStages); j++ {
-				o := &onlyUsedStages[j]
-				if o.BaseImageStoredLocally || o.BaseImageDigest == "" {
-					continue
-				}
-				if o.BaseImageDigest == s.BaseImageDigest {
-					s.BaseImageShared = true
-					o.BaseImageShared = true
-				}
-			}
-		}
-	}
 	return onlyUsedStages, nil
 }
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -1820,7 +1820,7 @@ func downloadExtraStages(images map[string]v1.Image, externalImageDigests map[st
 				return err
 			}
 		} else if sharedRemote[digest] {
-			stored, err := loadFromOCILayout(filepath.Join(config.KanikoBaseStagesDir, digest))
+			stored, err := loadSharedBase(digest)
 			if err == nil {
 				logrus.Infof("shared-base: loading %s from local store", digest)
 				sourceImage = stored

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1104,7 +1105,7 @@ type pushedLayer struct {
 	key  v1.Hash
 }
 
-func RenderStages(stages []config.KanikoStage, cacheInfo []*stageCacheInfo, opts *config.KanikoOptions, fileContext util.FileContext, crossStageDependencies map[int][]string, layerCache *memoizedLayerCache) (retErr error) {
+func RenderStages(stages []config.KanikoStage, cacheInfo []*stageCacheInfo, opts *config.KanikoOptions, fileContext util.FileContext, crossStageDependencies map[int][]string, layerCache *memoizedLayerCache, externalImageDigests map[string]string, sharedRemote map[string]bool) (retErr error) {
 	printf := func(format string, args ...any) {
 		if retErr == nil {
 			_, retErr = fmt.Fprintf(Out, format, args...)
@@ -1119,6 +1120,14 @@ func RenderStages(stages []config.KanikoStage, cacheInfo []*stageCacheInfo, opts
 	}
 	sources := mounts.Snapshot()
 	stageLayers := map[int][]pushedLayer{}
+	for _, ref := range slices.Sorted(maps.Keys(externalImageDigests)) {
+		if sharedRemote[externalImageDigests[ref]] {
+			printf("FETCH %s\n", ref)
+			printf("UNPACK %s %s%s\n", ref, config.KanikoInterStageDepsDir, ref)
+		} else {
+			printf("STREAM %s %s%s\n", ref, config.KanikoInterStageDepsDir, ref)
+		}
+	}
 	for _, s := range stages {
 		if s.Name != "" {
 			printf("FROM %s AS %s\n", s.BaseName, s.Name)
@@ -1130,7 +1139,7 @@ func RenderStages(stages []config.KanikoStage, cacheInfo []*stageCacheInfo, opts
 			printf("  UNPACK %s%d\n", config.KanikoIntermediateStagesDir, s.BaseImageIndex)
 			layers = slices.Clone(stageLayers[s.BaseImageIndex])
 		} else {
-			if s.BaseImageShared {
+			if sharedRemote[s.BaseImageDigest] {
 				printf("  FETCH %s\n", s.BaseName)
 				printf("  UNPACK %s\n", s.BaseName)
 			} else {
@@ -1294,6 +1303,14 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	if err != nil {
 		return nil, err
 	}
+	// legacy warmer overrides images override digest method to not return the digest
+	// as they get stored in a tarball and digest is lost in the process.
+	// But this also means that our defensive store and load here can't play nicely with them.
+	legacyCache := !config.FF.OCIWarmer && opts.Cache && opts.CacheDir != ""
+	var sharedRemote map[string]bool
+	if config.FF.SharedBaseCache && !legacyCache {
+		sharedRemote = sharedRemoteImages(kanikoStages, externalImageDigests, opts)
+	}
 
 	lastStage := kanikoStages[len(kanikoStages)-1]
 	assert.Assert("executor.build.last-stage-final", lastStage.Final, "last stage (index %d, name %q) must be the final stage", lastStage.Index, lastStage.Name)
@@ -1435,7 +1452,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	}
 
 	if opts.Dryrun || config.EnvBool("KANIKO_PRINT_PLAN") {
-		err := RenderStages(kanikoStages, cacheInfo, opts, fileContext, crossStageDependencies, layerCache)
+		err := RenderStages(kanikoStages, cacheInfo, opts, fileContext, crossStageDependencies, layerCache, externalImageDigests, sharedRemote)
 		if err != nil {
 			return nil, err
 		}
@@ -1444,7 +1461,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		}
 	}
 
-	if err := downloadExtraStages(extraStageImages); err != nil {
+	if err := downloadExtraStages(extraStageImages, externalImageDigests, sharedRemote); err != nil {
 		return nil, err
 	}
 
@@ -1495,7 +1512,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 
 	var pushImage v1.Image
 	for _, stage := range kanikoStages {
-		baseImage, err := retrieveBaseImage(stage, opts)
+		baseImage, err := retrieveBaseImage(stage, opts, sharedRemote[stage.BaseImageDigest])
 		if err != nil {
 			return nil, fmt.Errorf("failed to get baseImage: %w", err)
 		}
@@ -1791,13 +1808,25 @@ func resolveExtraStageDigests(stages []config.KanikoStage, opts *config.KanikoOp
 	return externalImageDigests, images, nil
 }
 
-func downloadExtraStages(images map[string]v1.Image) error {
+func downloadExtraStages(images map[string]v1.Image, externalImageDigests map[string]string, sharedRemote map[string]bool) error {
 	t := timing.Start("Fetching Extra Stages")
 	defer t.End()
 
 	for name, sourceImage := range images {
-		if err := saveStage(name, sourceImage); err != nil {
-			return err
+		digest := externalImageDigests[name]
+		if !config.FF.SharedBaseCache {
+			err := saveStage(name, sourceImage)
+			if err != nil {
+				return err
+			}
+		} else if sharedRemote[digest] {
+			stored, err := loadFromOCILayout(filepath.Join(config.KanikoBaseStagesDir, digest))
+			if err == nil {
+				logrus.Infof("shared-base: loading %s from local store", digest)
+				sourceImage = stored
+			} else {
+				sourceImage = storeImage(digest, sourceImage)
+			}
 		}
 		if err := extractImageToDependencyDir(name, sourceImage); err != nil {
 			return err
@@ -1859,35 +1888,68 @@ func loadSharedBase(digest string) (v1.Image, error) {
 	return img, nil
 }
 
-func retrieveBaseImage(stage config.KanikoStage, opts *config.KanikoOptions) (v1.Image, error) {
-	if !stage.BaseImageShared {
-		return image_util.RetrieveSourceImage(stage, opts)
+// sharedRemoteImages returns the digests of remote images that are read more than once,
+// by several stages, by a COPY --from, or by a re-read on push or save.
+func sharedRemoteImages(stages []config.KanikoStage, externalImageDigests map[string]string, opts *config.KanikoOptions) map[string]bool {
+	shared := map[string]bool{}
+	writesOutput := (!opts.NoPush && len(opts.Destinations) > 0) || opts.TarPath != "" || opts.OCILayoutPath != ""
+	reads := map[string]int{}
+	for _, s := range stages {
+		if s.BaseImageDigest == "" {
+			continue
+		}
+		reads[s.BaseImageDigest]++
+		if (s.SaveStage && !s.Final) || (s.Push && writesOutput) {
+			reads[s.BaseImageDigest]++
+		}
 	}
-	stored, err := loadSharedBase(stage.BaseImageDigest)
-	if err == nil {
-		logrus.Infof("shared-base: loading base %s from local store", stage.BaseImageDigest)
-		return stored, nil
+	for _, digest := range externalImageDigests {
+		reads[digest]++
 	}
+	for digest, n := range reads {
+		if n > 1 {
+			shared[digest] = true
+		}
+	}
+	return shared
+}
 
+func retrieveBaseImage(stage config.KanikoStage, opts *config.KanikoOptions, shared bool) (v1.Image, error) {
+	if shared {
+		stored, err := loadSharedBase(stage.BaseImageDigest)
+		if err == nil {
+			logrus.Infof("shared-base: loading %s from local store", stage.BaseImageDigest)
+			return stored, nil
+		}
+	}
 	img, err := image_util.RetrieveSourceImage(stage, opts)
 	if err != nil {
 		return nil, err
 	}
+	if !shared {
+		return img, nil
+	}
+	return storeImage(stage.BaseImageDigest, img), nil
+}
+
+// storeImage adds an image to the shared store and returns the stored copy. A store that
+// cannot be written or read back is not fatal, the caller keeps the registry image.
+func storeImage(digest string, img v1.Image) v1.Image {
+	path := filepath.Join(config.KanikoBaseStagesDir, digest)
 	t := timing.Start("Downloading base image")
-	path := filepath.Join(config.KanikoBaseStagesDir, stage.BaseImageDigest)
-	err = writeImageLayout(path, img, stage.BaseImageDigest)
+	err := writeImageLayout(path, img, digest)
 	t.End()
 	if err != nil {
-		logrus.Warnf("shared-base: failed to store %s, using registry image: %v", stage.BaseImageDigest, err)
-		return img, nil
+		logrus.Warnf("shared-base: failed to store %s, using registry image: %v", digest, err)
+		return img
 	}
-	stored, err = loadSharedBase(stage.BaseImageDigest)
+	stored, err := loadSharedBase(digest)
 	if err != nil {
-		logrus.Warnf("shared-base: failed to reload stored %s, using registry image: %v", stage.BaseImageDigest, err)
-		return img, nil
+		logrus.Warnf("shared-base: failed to reload stored %s, using registry image: %v", digest, err)
+		return img
 	}
-	logrus.Infof("shared-base: stored base %s", stage.BaseImageDigest)
-	return stored, nil
+	logrus.Infof("shared-base: stored %s", digest)
+	return stored
 }
 
 func getHasher(snapshotMode string) (func(string) (string, error), error) {


### PR DESCRIPTION
Part of #936, stacked on #937, so review that one first.

A remote image gets read in more places than the stage base loop. `COPY --from=<image>` resolves its own manifest keyed by the literal reference, writes an OCI layout to `/kaniko/stages/<name>` that nothing ever reads back, and then extracts the same lazy remote image into the dependency dir, so every external `COPY --from` pulls its layers twice and throws half of them away. None of that touched the shared base store either, so a Dockerfile with both `FROM debian:12.10` and `COPY --from=debian:12.10` paid for that image twice more.

So instead of the pairwise scan over stage bases, count the reads per digest across everything that reads one: stage bases, `COPY --from`, and the re-read on push or save. Store when the count is above one, stream when it is exactly one, and route both retrieval paths through the same store. An image nothing else reads keeps streaming, which is what removes the dead layout write. The count moves into `DoBuild` because external `COPY --from` digests are only resolved there, which is why this rewrites part of #937 rather than adding to it.

The plan output now lists the extra stages too, so the golden fixtures describe every registry read a build performs rather than staying silent about the ones outside the stage loop. `Dockerfile_test_multistage` already mixes `FROM debian:12.10` with `COPY --from=debian:12.10` and the integration suite runs with the flag on, so the store round trip for an extra stage is covered end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved multi-stage builds that copy files from external container images.
  * Added sharing and reuse of remote base images across build stages.
  * Added streaming support for external image content when appropriate.

* **Performance**
  * Reduced duplicate image downloads and storage during builds.
  * Added fallback retrieval when locally cached image content is unavailable.

* **Tests**
  * Expanded coverage for shared base layers and multiple external image copy operations.
  * Added scenarios covering streamed external image dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->