### PR TITLE
tracing: log export failures at debug, not warn

### DIFF
--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -56,7 +56,7 @@ func Init(ctx context.Context, opts *config.KanikoOptions) {
 	}
 	exp, err := otlptracehttp.New(ctx, otlptracehttp.WithEndpointURL(endpoint))
 	if err != nil {
-		logrus.Warnf("tracing disabled: failed to create OTLP exporter: %v", err)
+		logrus.Debugf("tracing disabled: failed to create OTLP exporter: %v", err)
 		return
 	}
 	// Read the Dockerfile once: reused for build_id and the content attribute.
@@ -69,7 +69,7 @@ func Init(ctx context.Context, opts *config.KanikoOptions) {
 		resource.WithAttributes(buildAttrs(opts, content)...),
 	)
 	if err != nil {
-		logrus.Warnf("tracing: partial resource, continuing: %v", err)
+		logrus.Debugf("tracing: partial resource, continuing: %v", err)
 	}
 	provider = sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exp),
@@ -154,7 +154,7 @@ func Shutdown(err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownFlushTimeout)
 	defer cancel()
 	if sderr := provider.Shutdown(ctx); sderr != nil {
-		logrus.Warnf("tracing: shutdown flush failed: %v", sderr)
+		logrus.Debugf("tracing: shutdown flush failed: %v", sderr)
 	}
 	provider = nil
 }


### PR DESCRIPTION
Tracing is opt-in and out-of-band. A span that never reaches the collector says nothing about whether the build succeeded, so an export problem should not surface as a build warning.

It also breaks CI. `checkNoWarnings` (`integration/images.go:400`) fails any build whose output carries an un-allowlisted `WARN`, so when the collector stalls past `shutdownFlushTimeout` (5s) the resulting

```
WARN[0007] tracing: shutdown flush failed: context deadline exceeded
```

fails the build under test — for reasons unrelated to the Dockerfile being built.

This is currently red on main. [Run 30430797680](https://github.com/osscontainertools/kaniko/actions/runs/30430797680) (the tracing merge itself) lost 27 `TestLayers` subtests to it, and [run 30431802052](https://github.com/osscontainertools/kaniko/actions/runs/30431802052) lost 7 — all 7 inside one six-second window, while parallel builds flushed against the same endpoint. The last run before tracing landed was green.

Demotes all three export-failure sites to `Debugf`: exporter construction, partial resource, and the shutdown flush. Each is reachable whenever the collector is unreachable or slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)