### PR TITLE
link to matrix channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,7 @@ For any community discussion [participate in open
 issues](https://github.com/osscontainertools/kaniko/issues) or [file a new
 issue](https://github.com/osscontainertools/kaniko/issues/new/choose).
 
-Some community members can be found on [#kaniko on Kubernetes
-Slack](https://kubernetes.slack.com/messages/CQDCHGX7Y/) but there is no active
-monitoring, regular availability, or access to older discussions.
+Join our official chat on Matrix at [#kaniko:matrix.org](https://app.element.io/#/room/#kaniko:matrix.org). It has dedicated rooms for [#support@kaniko:matrix.org](https://app.element.io/#/room/#support@kaniko:matrix.org) and [#announcements@kaniko:matrix.org](https://app.element.io/#/room/#announcements@kaniko:matrix.org). We will also continue to monitor discussions in the [#kaniko on Kubernetes Slack](https://kubernetes.slack.com/messages/CQDCHGX7Y/).
 
 ## Sponsorships
 We are grateful to the organizations and individuals who support our project.


### PR DESCRIPTION
We now have an official Matrix space at #kaniko:matrix.org with dedicated rooms for support and announcements. The README pointed people at the Kubernetes Slack channel with a caveat that nobody was really watching it, which is not a great first impression for someone looking for help. Matrix gives us rooms we control and searchable history, so it becomes the primary place to reach us. The Slack channel stays listed and monitored so nobody following an old link is left stranded.