### PR TITLE
document feature flags that ship default active

### DIFF
--- a/README.md
+++ b/README.md
@@ -1166,7 +1166,7 @@ FF_KANIKO_UNTAR_SKIP_ROOT=true
 
 ##### BuildKit compatibility
 
-In a few places, Kaniko keeps its historical, non-compliant behavior instead of following the Dockerfile specification. Switching to the compliant implementation by default would require users with large codebases to update their Dockerfiles, making migration to our fork tedious. These flags enable the spec-compliant behavior, matching BuildKit one-to-one. Our integration tests run this profile on top of Preview.
+In a few places, Kaniko keeps its historical, non-compliant behaviour instead of following the Dockerfile specification. Switching to the compliant implementation by default would require users with large codebases to update their Dockerfiles, making migration to our fork tedious. These flags enable the spec-compliant behaviour, matching BuildKit one-to-one. Our integration tests run this profile on top of Preview.
 
 ```sh
 FF_KANIKO_COPY_AS_ROOT=true

--- a/README.md
+++ b/README.md
@@ -1413,6 +1413,7 @@ Becomes default in `v1.29.0`.
 #### Flag `FF_KANIKO_SHARED_BASE_CACHE`
 
 When several stages build on the same remote base image, kaniko downloads that base once per stage. Set this flag to `true` to download a shared base once, store it under `/kaniko/bases`, and have the other stages read it from there instead of downloading it again. A base is also stored when a stage is kept for a later stage to build on, or when the built image is pushed, because both re-read the base layers. A base used by a single stage that is not pushed still streams, so nothing is stored that would not be read again.
+Stored bases stay in `/kaniko/bases` after the build, `--cleanup` does not remove them. A long-lived executor that runs many builds therefore accumulates every base it ever downloaded.
 Defaults to `false`.
 Becomes default in `v1.29.0`.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,31 +4,33 @@
 
 kaniko ships on a fixed schedule, independent of what has been merged:
 
-- **Patch release** (`1.X.Y`) every two weeks: bug fixes only, no behavior changes.
-- **Minor release** (`1.X.0`) roughly every three months: new behavior is graduated from feature flags to defaults, and old flags are removed.
+- **Patch release** (`1.X.Y`) every two weeks: bug fixes only, no behaviour changes.
+- **Minor release** (`1.X.0`) roughly every three months: new behaviour is graduated from feature flags to defaults, and old flags are removed.
 
-The version number is decided in advance. A patch release will never contain behavior changes, regardless of what is available in the codebase. This means users can safely bump a patch version knowing nothing will behave differently.
+The version number is decided in advance. A patch release will never contain behaviour changes, regardless of what is available in the codebase. This means users can safely bump a patch version knowing nothing will behave differently.
 
 ## Feature flags
 
-Because minor releases are infrequent, new behavior ships immediately behind a [feature flag](../README.md#feature-flags) rather than waiting for the next minor cycle. This gives users who want to try the feature early a way to opt-in, while everyone else gets the usual patch-release stability guarantee.
+Because minor releases are infrequent, new behaviour ships immediately behind a [feature flag](../README.md#feature-flags) rather than waiting for the next minor cycle. This gives users who want to try the feature early a way to opt-in, while everyone else gets the usual patch-release stability guarantee.
 
 The graduation lifecycle of a feature flag is:
 
-1. **Introduced**: flag defaults to `false`, behavior is opt-in. Ships in the next patch release.
+1. **Introduced**: flag defaults to `false`, behaviour is opt-in. Ships in the next patch release.
 2. **Becomes default**: flag defaults to `true` in the next minor release. Existing opt-in users are unaffected.
 3. **Deprecated**: flag is removed in a subsequent minor release.
 
-This means a new behavior is opt-in for at least two weeks and up to three months, then opt-out for a further three months before the flag disappears entirely. Users have between three and six months to react to any change. We expect most users to upgrade roughly once per quarter rather than every two weeks, so in practice the full window is available to them.
+This means a new behaviour is opt-in for at least two weeks and up to three months, then opt-out for a further three months before the flag disappears entirely. Users have between three and six months to react to any change. We expect most users to upgrade roughly once per quarter rather than every two weeks, so in practice the full window is available to them.
 
 - `FF_KANIKO_*` gates a new feature, `true` enables it.
-- `FF_KANIKO_DEPRECATE_*` gates the removal of existing behavior, `true` removes it.
+- `FF_KANIKO_DEPRECATE_*` gates the removal of existing behaviour, `true` removes it.
 
 ## Do I need a feature flag?
 
-The goal of a feature flag is to let users upgrade kaniko safely without surprises. Any change that could affect whether a build succeeds, what image it produces, or how long it takes should be gated behind a flag, even if the change is correct, even if it is a performance improvement, and even if the previous behavior was technically wrong. Some users will have built workflows around the old behavior and need time to migrate. Others will be running kaniko in environments where a new code path fails in ways the old one did not. A feature flag gives them the escape hatch.
+The goal of a feature flag is to let users upgrade kaniko safely without surprises. Any change that could affect whether a build succeeds, what image it produces, or how long it takes should be gated behind a flag, even if the change is correct, even if it is a performance improvement, and even if the previous behaviour was technically wrong. Some users will have built workflows around the old behaviour and need time to migrate. Others will be running kaniko in environments where a new code path fails in ways the old one did not. A feature flag gives them the escape hatch.
 
-The only exception is a fix for behavior that was so broken that no working workflow could have depended on it: kaniko was erroring out, crashing, or producing corrupt images. There is no stable behavior to protect in that case, and making users wait three months for a minor release would cause more harm than the fix itself.
+The only exception is a fix for behaviour that was so broken that no working workflow could have depended on it: kaniko was erroring out, crashing, or producing corrupt images. There is no stable behaviour to protect in that case, and making users wait three months for a minor release would cause more harm than the fix itself.
+
+There is a greyzone where the behaviour is genuinely new and a workflow might exist, but it would harm the majority of the users to wait, a security patch for example. A compromise is to skip the opt-in phase and release the feature flag as default `true` from the start. This way, if the behaviour does break someone's workflow they at least have an escape hatch and can disable the feature.
 
 When in doubt, open an issue and ask.
 


### PR DESCRIPTION
The release policy only described flags that start opt-in, but we have shipped flags that default to `true` from the start, for instance `FF_KANIKO_SECUREJOIN_EXTRACTION`. That is the right call when the old behaviour is broken enough that waiting a full minor cycle hurts more users than the change does, and the flag then serves purely as an escape hatch. Writing it down so the next such case does not have to relitigate whether a flag is needed at all. Also settles on british `behaviour` in both documents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized spelling in the BuildKit compatibility documentation.
  * Clarified release-policy guidance for grey-area changes, including urgent fixes that may ship behind an enabled-by-default feature flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->