### PR TITLE
mz332: fold the onbuild copy image into the test dockerfile

### DIFF
--- a/integration/dockerfiles/Dockerfile_onbuild_copy
+++ b/integration/dockerfiles/Dockerfile_onbuild_copy
@@ -1,2 +1,0 @@
-FROM busybox:latest
-ONBUILD COPY --from=base /blubb /blubb

--- a/integration/dockerfiles/Dockerfile_test_issue_mz332
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz332
@@ -1,7 +1,19 @@
+# mz332: the final stage's base image carries `ONBUILD COPY --from=base`, so the
+# final stage depends on stage `base` without ever naming it here. The dependency
+# only becomes visible once the remote base image config is resolved, which is why
+# stage elimination must not drop `base`.
 ARG IMAGE_REPO
+
+# Stage `onbuild` is pushed by test setup (`docker build --target=onbuild`) as
+# `onbuild-copy:latest`, the base image of the final stage below. It only records
+# the trigger, it never runs it, so /blubb is not part of it.
+FROM ${IMAGE_REPO}busybox AS onbuild
+ONBUILD COPY --from=base /blubb /blubb
+
 FROM ${IMAGE_REPO}busybox AS base
 RUN touch /blubb
 
+# Unnamed and unreferenced. Kaniko must never try to resolve it.
 FROM doesnt:exist
 
 FROM ${IMAGE_REPO}onbuild-copy:latest

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -144,7 +144,7 @@ func buildRequiredImages() error {
 		command: []string{"docker", "build", "--push", "-t", config.onbuildBaseImage, "-f", dockerfilesPath + "/Dockerfile_onbuild_base", "."},
 	}, {
 		name:    "Building onbuild copy image",
-		command: []string{"docker", "build", "--push", "-t", config.onbuildCopyImage, "-f", dockerfilesPath + "/Dockerfile_onbuild_copy", "."},
+		command: []string{"docker", "build", "--push", "-t", config.onbuildCopyImage, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz332", "--target", "onbuild", "."},
 	}, {
 		name:    "Building hardlink base image",
 		command: []string{"docker", "build", "--push", "-t", config.hardlinkBaseImage, "-f", dockerfilesPath + "/Dockerfile_hardlink_base", "."},


### PR DESCRIPTION
The mz332 repro was split across two files. The scenario it exercises is subtle, the final stage inherits an `ONBUILD COPY --from=base` from its remote base image, so it depends on stage `base` without ever naming it, and that dependency only surfaces once the base config is resolved. Reading it meant jumping to `Dockerfile_onbuild_copy` to find out where the trigger came from. Building that image from a named `onbuild` target in the same file keeps the whole scenario in one place and lets the comments explain why stage elimination must not drop `base` and why the unreferenced `FROM doesnt:exist` stage is there on purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated on-build copy integration coverage to use a dedicated BusyBox-based build stage.
  * Verified that deferred file-copy triggers remain available without prematurely copying files into the resulting image.
  * Removed obsolete on-build copy configuration from the test fixture.
  * Improved validation of staged build behavior and ensured expected image contents are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->