### PR TITLE
mz960: don't squash a base stage that declares ONBUILD

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz960
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz960
@@ -1,0 +1,14 @@
+# mz960: the cache-consume build aborts on a COPY --from that reaches a stage
+# eliminated by FF_KANIKO_SKIP_CACHED_STAGES. Fails on main@93be5ff96 with
+# CACHE_LOOKAHEAD + SKIP_CACHED_STAGES + INFER_CROSS_STAGE_CACHE_KEY on.
+# Squashing drops the base stage's ONBUILD declaration from the command list,
+# so the squashed chain hashes fewer commands than the lookahead did. Every key
+# after the ONBUILD diverges, the inferred cross-stage key misses, and the build
+# falls back to hashing the source files under /kaniko/deps/0 which the
+# eliminated stage never wrote.
+FROM busybox AS stage0
+ONBUILD RUN echo ob0 > /onbuild0
+RUN echo stage0 > /artifact
+
+FROM stage0 AS stage1
+COPY --from=0 /artifact /from-0

--- a/integration/images.go
+++ b/integration/images.go
@@ -98,6 +98,7 @@ var envsMap = map[string][]string{
 	"Dockerfile_test_issue_cg188": {"SECRET=blubb"},
 	"Dockerfile_test_issue_mz775": {"FF_KANIKO_CACHE_LOOKAHEAD=0"},
 	"Dockerfile_test_issue_mz334": {"FF_KANIKO_SKIP_CACHED_STAGES=1"},
+	"Dockerfile_test_issue_mz960": {"FF_KANIKO_SKIP_CACHED_STAGES=1"},
 	"Dockerfile_test_issue_mz793": {"FF_KANIKO_VOLUME_SKIP_MKDIR=0"},
 	"Dockerfile_test_issue_mz473": {"KANIKO_DIR=/kaniko2"},
 	"Dockerfile_test_issue_mz661": {"KANIKO_DIR=/kaniko2"},
@@ -207,6 +208,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_target":                     {"--target=second"},
 	"Dockerfile_test_snapshotter_ignorelist":     {"--use-new-run=true", "-v=trace"},
 	"Dockerfile_test_issue_mz334":                {"--cache-copy-layers=true"},
+	"Dockerfile_test_issue_mz960":                {"--cache-copy-layers=true"},
 	"Dockerfile_test_issue_mz879":                {"--cache-copy-layers=true", "--use-new-run"},
 	"Dockerfile_test_issue_mz896":                {"--cache-copy-layers=true", "--cache-run-layers=false"},
 	"Dockerfile_test_issue_mz787":                {"--cache=true"},
@@ -538,6 +540,7 @@ func NewDockerFileBuilder() *DockerFileBuilder {
 		"Dockerfile_test_issue_mz793":   {},
 		"Dockerfile_test_issue_mz879":   {},
 		"Dockerfile_test_issue_mz896":   {},
+		"Dockerfile_test_issue_mz960":   {},
 	}
 	d.TestOCICacheDockerfiles = map[string]struct{}{
 		"Dockerfile_test_cache_oci":         {},

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -1309,10 +1309,20 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 				}
 			}
 		}
+	squash:
 		for i, s := range kanikoStages {
 			if buildTargets[s.Index] || stagesDependencies[s.Index] > 0 || copyDependencies[s.Index] > 0 {
 				if s.BaseImageStoredLocally && stagesDependencies[s.BaseImageIndex] == 1 && copyDependencies[s.BaseImageIndex] == 0 {
 					sb := kanikoStages[position[s.BaseImageIndex]]
+					for _, c := range sb.Commands {
+						_, isOnbuild := c.(*instructions.OnbuildCommand)
+						if isOnbuild {
+							// mz960: squashing drops the base stage's ONBUILD declarations, so the
+							// merged chain hashes fewer commands than the lookahead did and every
+							// key after the ONBUILD diverges
+							continue squash
+						}
+					}
 					// squash stages[i] into stages[i].BaseName
 					logrus.Infof("Squashing stages: %s into %s", s.Name, sb.Name)
 					// We squash the base stage into the current stage because,


### PR DESCRIPTION
Fixes #960

Squashing filters the base stage's ONBUILD declaration out of the merged command list. That is fine for the squash in MakeKanikoStages, which runs before any cache key exists, but the stage elimination behind FF_KANIKO_SKIP_CACHED_STAGES squashes after the lookahead has already hashed the unsquashed chain. The merged chain then hashes one command fewer, so every key after the ONBUILD diverges from the precomputed one. On a cache-consume build the inferred cross-stage key misses, the COPY --from falls back to hashing its source files, and the build aborts because the stage it reads from was eliminated and never wrote /kaniko/deps/N. So we leave a base stage that declares an ONBUILD unsquashed, it stays alive and writes its deps like it does with the flag off.