### PR TITLE
update the feature flag profiles

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -102,9 +102,16 @@ Usage: `/release <version>`
 
 14. **Consistency check** — compare entry style, capitalisation, and backtick usage against the two previous release entries. Fix deviations.
 
+14b. **Feature flag profiles** — reconcile the two profile lists under `### Feature Flags` → `#### Profiles` in `README.md`:
+    ```bash
+    awk '/^#### Flag `FF_KANIKO_/{f=$0} /Becomes default in/{print f" -> "$0}' README.md
+    grep -n "FF_KANIKO_" integration/images.go
+    ```
+    Preview lists every default-off flag documented as becoming default in the next minor. BuildKit compatibility lists the flags that align behaviour with the spec, the profile the integration suite runs on top of Preview. Add the flags this release introduced, drop the ones that became default in it. Keep both lists sorted alphabetically.
+
 15. **Commit**:
     ```
-    git add Makefile CHANGELOG.md CHANGELOG_OVERVIEW.md
+    git add Makefile CHANGELOG.md CHANGELOG_OVERVIEW.md README.md
     git commit -m "release"
     ```
     ```

--- a/README.md
+++ b/README.md
@@ -1160,6 +1160,8 @@ FF_KANIKO_RESOLVE_CACHE_KEY=true
 FF_KANIKO_ROLLING_CACHE_KEY=true
 FF_KANIKO_RUN_HONOR_GROUP=true
 FF_KANIKO_RUN_VIA_TINI=true
+FF_KANIKO_SHARED_BASE_CACHE=true
+FF_KANIKO_SKIP_CACHED_STAGES=true
 FF_KANIKO_SKIP_RELABEL_RECOMPRESS=true
 FF_KANIKO_SKIP_WRITE_WHITEOUTS=true
 FF_KANIKO_UNTAR_SKIP_ROOT=true
@@ -1170,6 +1172,7 @@ FF_KANIKO_UNTAR_SKIP_ROOT=true
 In a few places, Kaniko keeps its historical, non-compliant behaviour instead of following the Dockerfile specification. Switching to the compliant implementation by default would require users with large codebases to update their Dockerfiles, making migration to our fork tedious. These flags enable the spec-compliant behaviour, matching BuildKit one-to-one. Our integration tests run this profile on top of Preview.
 
 ```sh
+FF_KANIKO_CHOWN_ON_IMPLICIT_DIRS=true
 FF_KANIKO_COPY_AS_ROOT=true
 FF_KANIKO_COPY_CHMOD_ON_IMPLICIT_DIRS=true
 FF_KANIKO_EXPAND_HEREDOC=true


### PR DESCRIPTION
The v1.28.2 flags never made it into the profile lists, so anyone copying Preview missed `FF_KANIKO_SHARED_BASE_CACHE` and `FF_KANIKO_SKIP_CACHED_STAGES`, and the BuildKit compatibility profile missed `FF_KANIKO_CHOWN_ON_IMPLICIT_DIRS`. The release command now reconciles both lists so the next release does not drift again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature-flag profile documentation to include shared base cache and cached-stage options in the Preview profile.
  * Added the implicit-directory ownership option to the BuildKit compatibility profile.
  * Clarified profile semantics and maintained alphabetical feature-flag listings for release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->