### PR TITLE
hub-sync: collapse old releases and check overview length

### DIFF
--- a/.claude/commands/hub-sync.md
+++ b/.claude/commands/hub-sync.md
@@ -43,4 +43,15 @@ Usage: `/hub-sync`
    [$VERSION-bootstrap](.../$VERSION-bootstrap/images/<digest-bootstrap>)
    ```
 
+   Only the current minor keeps digest links. Older minors collapse to one line each, no blank lines between, and the outgoing minor collapses when a new section opens:
+   ```
+   * $VERSION ([DD.MM.YYYY](.../releases/tag/$VERSION))
+   ```
+
 5. **Write result to `hub-sync.md`.**
+
+6. **Check size**, must be under 25000 bytes (Docker Hub limit):
+   ```bash
+   wc -c hub-sync.md
+   ```
+   Full entry ~1050 bytes, collapsed ~90. Over the limit: collapse the oldest minor that still has digest links.


### PR DESCRIPTION
The Docker Hub API rejected the v1.28.2 overview update because the description had grown to 25686 bytes against a 25000 byte limit. Every release added roughly a kilobyte of per-variant digest links, so the page was always going to hit the wall, it just happened to be this release. Older releases now collapse to a single line carrying the version, the date and a link to the release notes, and only the current minor keeps the six digest links that people actually pin against. That took the page from 25.7KB to 6.6KB. The command also checks the byte count at the end now, so the next run finds out before Docker Hub does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release synchronization guidance to use compact, one-line entries without image links for older minor releases.
  * Clarified that only the current minor release retains six detailed digest links.
  * Added instructions to collapse the previous minor when starting a new minor version.
  * Added Docker Hub description size checks and guidance for staying within the 25,000-byte limit, including collapsing the oldest digest-bearing minor when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->