### PR TITLE
mz978: key hardlink tracking by device and inode

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz978
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz978
@@ -1,0 +1,18 @@
+ARG IMAGE_REPO
+# mz978: COPY of a tree spanning two filesystems hardlinks unrelated files together.
+# Copies the wrong content since main@0788bdcac with FF_KANIKO_NATIVE_COPY=1.
+FROM ${IMAGE_REPO}busybox AS base
+
+# /data/a and /data/b are separate tmpfs mounts for kaniko build and only kaniko build.
+RUN mkdir -p /data/a /data/b \
+    # kaniko tmpfs root comes up 1777 where docker mkdir gives 0755.
+    && chmod 755 /data/a /data/b \
+    # Every tmpfs numbers its own inodes from scratch, so both 1 files land on inode 2.
+    && echo 'bli' > /data/a/1 && ln /data/a/1 /data/a/2 \
+    && echo 'blubb' > /data/b/1 && ln /data/b/1 /data/b/2
+
+FROM ${IMAGE_REPO}busybox
+# checkCopyHardlink keys its seen-map by inode number alone, but an inode number is
+# only unique within one filesystem. /data/b/1 matches /data/a/1 on inode number and
+# gets linked to it instead of copied, so /out/b/1 holds bli rather than blubb.
+COPY --from=base /data /out

--- a/integration/images.go
+++ b/integration/images.go
@@ -963,6 +963,11 @@ var extraDockerRunFlags = map[string]func(contextDir string) []string{
 	"Dockerfile_test_issue_mz936": func(ctx string) []string {
 		return []string{"-v", filepath.Join(ctx, "testdata") + ":/kaniko/bases:ro"}
 	},
+	// Two filesystems in the rootfs, without needing privileges. Every tmpfs numbers
+	// its own inodes from scratch, so both hand their first file the same inode number.
+	"Dockerfile_test_issue_mz978": func(_ string) []string {
+		return []string{"--tmpfs", "/data/a", "--tmpfs", "/data/b"}
+	},
 }
 
 func buildKanikoImage(

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -779,7 +779,7 @@ func CopyDir(src, dest string, context FileContext, uid, gid int64, chmod mode.S
 func copyDirInner(files []string, src, dest string, context FileContext, uid, gid int64, chmod mode.Set, useDefaultChmod bool, skipIgnoreList bool) ([]string, error) {
 	var copiedFiles []string
 	var updates []timestampUpdate
-	hardlinksSeen := make(map[uint64]string)
+	hardlinksSeen := make(map[hardlinkKey]string)
 	for _, file := range files {
 		fullPath := filepath.Join(src, file)
 		if skipIgnoreList && HasFilepathPrefix(fullPath, config.KanikoDir, false) {
@@ -925,15 +925,20 @@ func CreateFifo(src, dest string, fi os.FileInfo, context FileContext, uid, gid 
 	return false, os.Lchown(dest, int(uid), int(gid))
 }
 
-func checkCopyHardlink(fi os.FileInfo, dest string, seen map[uint64]string) (string, bool) {
+type hardlinkKey struct {
+	dev, ino uint64
+}
+
+func checkCopyHardlink(fi os.FileInfo, dest string, seen map[hardlinkKey]string) (string, bool) {
 	stat := getSyscallStatT(fi)
 	if stat == nil || stat.Nlink <= 1 {
 		return "", false
 	}
-	if existing, ok := seen[stat.Ino]; ok {
+	key := hardlinkKey{dev: stat.Dev, ino: stat.Ino}
+	if existing, ok := seen[key]; ok {
 		return existing, true
 	}
-	seen[stat.Ino] = dest
+	seen[key] = dest
 	return "", false
 }
 

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -37,7 +37,7 @@ import (
 
 // Tar knows how to write files to a tar file.
 type Tar struct {
-	hardlinks map[uint64]string
+	hardlinks map[hardlinkKey]string
 	w         *tar.Writer
 }
 
@@ -46,7 +46,7 @@ func NewTar(f io.Writer) Tar {
 	w := tar.NewWriter(f)
 	return Tar{
 		w:         w,
-		hardlinks: map[uint64]string{},
+		hardlinks: map[hardlinkKey]string{},
 	}
 }
 
@@ -180,13 +180,13 @@ func (t *Tar) checkHardlink(p string, i os.FileInfo) (bool, string) {
 	if stat != nil {
 		nlinks := stat.Nlink
 		if nlinks > 1 {
-			inode := stat.Ino
-			if original, exists := t.hardlinks[inode]; exists && original != p {
+			key := hardlinkKey{dev: stat.Dev, ino: stat.Ino}
+			if original, exists := t.hardlinks[key]; exists && original != p {
 				hardlink = true
 				logrus.Debugf("%s inode exists in hardlinks map, linking to %s", p, original)
 				linkDst = original
 			} else {
-				t.hardlinks[inode] = p
+				t.hardlinks[key] = p
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #978

Hardlink tracking keyed its seen-map by inode number alone, in `checkCopyHardlink` for the copy path and in `Tar.checkHardlink` for the snapshot path. An inode number is only unique within one filesystem, so a `COPY` of a tree that spans a mount point could match two unrelated files and hardlink them together, leaving one with the other's content. Nothing failed loudly, because the link target is a destination path already written and both ends sit on the destination filesystem, so there is no EXDEV to catch. Both maps now key on `{dev, ino}`, fixed together so the two implementations do not drift apart again.

No feature flag. Per `docs/releases.md` a fix for behaviour that produced corrupt images has no stable behaviour to protect, and gating it would mean shipping known content corruption behind an opt-in.

The bug predates this stack and reproduces on main through `COPY` from the build context, but `FF_KANIKO_NATIVE_COPY` widens it considerably: it routes the multistage save path through `copyDirInner`, and that one walks the source stage's live rootfs, which always spans several filesystems. That is why this is stacked ahead of the flag graduating to default in v1.29.0, and why the test uses `COPY --from`.

Getting a deterministic collision turned out not to need privileges. Two tmpfs mounts do it, since a tmpfs numbers its inodes per superblock, so each mount hands its first file inode 2. `extraDockerRunFlags` already existed for per-test docker run flags, so no harness change was needed. Only the executor gets the mounts, so the docker half of the comparison keeps one filesystem and stays correct, and diffoci names the defect directly rather than a shell assertion returning a bare exit code:

```
TYPE    NAME       INPUT-0             INPUT-1
File    out/b/1    Linkname            Linkname out/a/1
File    out/b/2    Linkname out/b/1    Linkname out/a/1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file copying and archiving when files on separate filesystems share the same inode number.
  * Prevented unrelated files from being incorrectly treated as hardlinks, preserving their distinct contents.
  * Ensured files from separate filesystems remain independent even when their inode numbers match.
  * Added integration coverage for cross-filesystem hardlink handling.
  * Improved reliability when processing hardlinked files during directory copying and archive creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->