### PR TITLE
integration: log build output as an argument, not a format string

### DIFF
--- a/integration/images.go
+++ b/integration/images.go
@@ -736,7 +736,7 @@ func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTes
 	kanikoCmd := exec.Command("docker", dockerRunFlags...)
 
 	out, err := RunCommandWithoutTest(kanikoCmd)
-	logf(string(out))
+	logf("%s", out)
 
 	if err != nil {
 		return fmt.Errorf("failed to build cached image %s with kaniko command \"%s\": %w", kanikoImage, kanikoCmd.Args, err)
@@ -786,7 +786,7 @@ func (d *DockerFileBuilder) buildCachedImageInContext(logf logger, config *integ
 		"--cache-dir", cacheDir)
 
 	out, err := RunCommandWithoutTest(exec.Command("docker", dockerRunFlags...))
-	logf(string(out))
+	logf("%s", out)
 	return err
 }
 
@@ -811,7 +811,7 @@ func populateVolumeCache(logf logger) error {
 
 	warmerCmd := exec.Command("docker", cmd...)
 	out, err := RunCommandWithoutTest(warmerCmd)
-	logf(string(out))
+	logf("%s", out)
 	if err != nil {
 		return fmt.Errorf("failed to warm kaniko cache: %w", err)
 	}
@@ -852,7 +852,7 @@ func (d *DockerFileBuilder) buildWarmerImage(logf logger, config *integrationTes
 	kanikoCmd := exec.Command("docker", dockerRunFlags...)
 
 	out, err := RunCommandWithoutTest(kanikoCmd)
-	logf(string(out))
+	logf("%s", out)
 
 	if err != nil {
 		return fmt.Errorf("failed to build image %s with kaniko command \"%s\": %w", kanikoImage, kanikoCmd.Args, err)
@@ -916,7 +916,7 @@ func (d *DockerFileBuilder) buildRelativePathsImage(logf logger, imageRepo, dock
 	kanikoCmd := exec.Command("docker", dockerRunFlags...)
 
 	out, err = RunCommandWithoutTest(kanikoCmd)
-	logf(string(out))
+	logf("%s", out)
 
 	if err != nil {
 		return fmt.Errorf(
@@ -1014,7 +1014,7 @@ func buildKanikoImage(
 	kanikoCmd := exec.Command("docker", dockerRunFlags...)
 
 	out, err := RunCommandWithoutTest(kanikoCmd)
-	logf(string(out))
+	logf("%s", out)
 
 	if err != nil {
 		return fmt.Errorf("failed to build image %s with kaniko command \"%s\": %w", kanikoImage, kanikoCmd.Args, err)


### PR DESCRIPTION
`logger` is `func(string, ...any)`, so `logf(string(out))` hands captured build output to a Printf-style call as the format string. Every percent sign in a build log is then read as a verb with nothing to fill it, and the log shows `%!a(MISSING)` where the build actually printed `%a`. Six call sites did this, so it hit every kaniko and warmer invocation in the suite.

It only corrupts diagnostics, never a build or a verdict, but it corrupts them exactly when a test has failed and the log is the thing you are reading. Any Dockerfile using a percent in a `RUN` trips it, `stat -c`, `date +%Y`, `printf`, `awk`. It cost me a debugging round on a `stat -c %i` assertion that looked like a mangled command rather than a mangled log line.

`go vet` does not catch it. Vet recognises printf wrappers by analysing a body that forwards to a known printf function, and `logf` is a parameter of a function type, so there is no body to classify at the call site.

Verified on `Dockerfile_test_issue_mz863`, which asserts with `stat -c '%a'`. Four mangled spots in the log before, zero after, test still passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging of Kaniko and Docker command output for clearer build and cache-related messages.
  * Preserved existing build, cache warming, path handling, and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->