### PR TITLE
Record where a fetched image came from so a stored base can still mount

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -1232,9 +1232,9 @@ func RenderStages(w io.Writer, stages []config.KanikoStage, cacheInfo []*stageCa
 				var source name.Repository
 				serves := config.FF.CrossRepoMount && len(registries) > 0
 				for _, registry := range registries {
-					repo, ok := mounts.Mountable(sources[l.key], registry)
+					i, ok := mounts.Mountable(sources[l.key], registry)
 					if ok {
-						source = repo
+						source = sources[l.key][i]
 					} else {
 						serves = false
 					}

--- a/pkg/image/remote/remote.go
+++ b/pkg/image/remote/remote.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/osscontainertools/kaniko/pkg/config"
 	"github.com/osscontainertools/kaniko/pkg/creds"
+	"github.com/osscontainertools/kaniko/pkg/mounts"
 	"github.com/osscontainertools/kaniko/pkg/util"
 	"github.com/sirupsen/logrus"
 )
@@ -74,6 +75,12 @@ func RetrieveRemoteImage(image string, opts config.RegistryOptions, customPlatfo
 			}
 
 			manifestCache[image] = remoteImage
+			if config.FF.CrossRepoMount {
+				// a registry-map implies that the original also holds the image,
+				// and we might push there, so record it as a possible mount reference too.
+				mounts.RecordImage(remoteImage, remappedRef.Context())
+				mounts.RecordImage(remoteImage, ref.Context())
+			}
 
 			return remoteImage, nil
 		}
@@ -101,6 +108,9 @@ func RetrieveRemoteImage(image string, opts config.RegistryOptions, customPlatfo
 	var remoteImage v1.Image
 	if remoteImage, err = util.RetryWithResult(retryFunc, opts.ImageDownloadRetry, 1000); remoteImage != nil {
 		manifestCache[image] = remoteImage
+		if config.FF.CrossRepoMount {
+			mounts.RecordImage(remoteImage, ref.Context())
+		}
 	}
 
 	return remoteImage, err

--- a/pkg/image/remote/remote.go
+++ b/pkg/image/remote/remote.go
@@ -79,7 +79,7 @@ func RetrieveRemoteImage(image string, opts config.RegistryOptions, customPlatfo
 				// a registry-map implies that the original also holds the image,
 				// and we might push there, so record it as a possible mount reference too.
 				mounts.RecordImage(remoteImage, remappedRef.Context())
-				mounts.RecordImage(remoteImage, ref.Context())
+				mounts.RecordGuess(remoteImage, ref.Context())
 			}
 
 			return remoteImage, nil

--- a/pkg/mounts/mounts.go
+++ b/pkg/mounts/mounts.go
@@ -21,9 +21,9 @@ limitations under the License.
 // from, which every local copy kaniko makes throws away. Keyed by digest rather than held on
 // the layer, so a copy that keeps the bytes keeps the entry and one that rewrites them misses.
 //
-// Only repositories this process read from or wrote to belong here. remote.Write fails a push
-// outright when the token request for a mount source is refused, so an unproven entry is not
-// a missed optimisation but a broken build.
+// The most recent repository this process read from or wrote to wins, an older one may still
+// hold the layer but is the staler answer. A guess never displaces one of those, remote.Write
+// fails a push when the token request for a mount source is refused and costs it a plain retry.
 package mounts
 
 import (
@@ -41,6 +41,14 @@ var (
 )
 
 func RecordImage(img v1.Image, repo name.Repository) {
+	record(img, repo, false)
+}
+
+func RecordGuess(img v1.Image, repo name.Repository) {
+	record(img, repo, true)
+}
+
+func record(img v1.Image, repo name.Repository, guess bool) {
 	layers, err := img.Layers()
 	if err != nil {
 		return
@@ -51,9 +59,11 @@ func RecordImage(img v1.Image, repo name.Repository) {
 		digest, err := l.Digest()
 		if err == nil {
 			// One repository per registry is all a push can ever use.
-			_, known := Mountable(sources[digest], repo.RegistryStr())
+			i, known := Mountable(sources[digest], repo.RegistryStr())
 			if !known {
 				sources[digest] = append(sources[digest], repo)
+			} else if !guess {
+				sources[digest][i] = repo
 			}
 		}
 	}
@@ -75,13 +85,13 @@ func Snapshot() map[v1.Hash][]name.Repository {
 
 // Mountable returns one of the repositories known to hold a layer that sits on registry.
 // Cross-registry origins are not honoured in practice, so a source elsewhere is no source.
-func Mountable(repos []name.Repository, registry string) (name.Repository, bool) {
-	for _, repo := range repos {
+func Mountable(repos []name.Repository, registry string) (int, bool) {
+	for i, repo := range repos {
 		if repo.RegistryStr() == registry {
-			return repo, true
+			return i, true
 		}
 	}
-	return name.Repository{}, false
+	return 0, false
 }
 
 func MountableImage(img v1.Image, registry string) v1.Image {
@@ -108,8 +118,9 @@ func (m *mountableImage) Layers() ([]v1.Layer, error) {
 		layer := l
 		digest, err := l.Digest()
 		if err == nil {
-			repo, ok := Mountable(sources[digest], m.registry)
+			i, ok := Mountable(sources[digest], m.registry)
 			if ok {
+				repo := sources[digest][i]
 				layer = &remote.MountableLayer{Layer: l, Reference: repo.Digest(digest.String())}
 			}
 		}


### PR DESCRIPTION
Fixes #970

Stacked on #990, review that one first.

`FF_KANIKO_SHARED_BASE_CACHE` reads the base back out of `/kaniko/bases` as a layout image, and layout layers carry no reference, so `remote.Write` cannot offer them for a cross-repo mount. When the base and the destination live on the same registry that turns a metadata-only mount into a full upload of every base layer, which is what #970 measured.

#990 already has the machinery, it just had no producer for this path. `RetrieveRemoteImage` is the one place that knows the reference it actually resolved, so recording there covers every remote image kaniko fetches through it and needs nothing recovered from a layer afterwards.

Both references get recorded on the mapped path. A pull-through cache proxies a registry that also holds the blob, and that registry is often the push destination, so the destination registry gets to be the one that matches rather than kaniko guessing which is useful.

Measured against a local registry with the base copied into it, `FROM localhost:5000/basecopy/alpine:3.20` plus a `COPY`, pushed to a fresh repository:

| flags | base layer |
| --- | --- |
| `SHARED_BASE_CACHE` only | uploaded |
| `SHARED_BASE_CACHE` + `CROSS_REPO_MOUNT` | mounted |
| neither | mounted, ggcr does it unaided |

The middle row is the fix. The last row is the behaviour the store took away in the first place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tracking of remotely retrieved images across repository mappings.
  * When cross-repository mounting is enabled, images are recorded under both mapped and original repository references.
  * Directly retrieved images are tracked using their registry references.
  * Enhanced layer tracking associates expected repositories without replacing established repository information, improving image retrieval and layer reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->