### PR TITLE
mz992: skip the push on a dryrun

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -204,7 +204,8 @@ var RootCmd = &cobra.Command{
 			}
 			logrus.Warn("Kaniko is being run outside of a container. This can have dangerous effects on your system")
 		}
-		if !opts.NoPush || opts.CacheRepo != "" {
+		// mz992: a dryrun only renders the plan, it never pushes a layer or a cache entry.
+		if !opts.Dryrun && (!opts.NoPush || opts.CacheRepo != "") {
 			if err := executor.CheckPushPermissions(opts); err != nil {
 				logrus.Warnf("make sure you entered the correct tag name, that you are authenticated correctly, and try again.")
 				// mz280: remind users that DOCKER_AUTH_CONFIG gets prioritized by docker-cli

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -235,8 +235,11 @@ var RootCmd = &cobra.Command{
 		if err != nil {
 			exit(fmt.Errorf("error building image: %w", err))
 		}
-		if err := executor.DoPush(image, opts); err != nil {
-			exit(fmt.Errorf("error pushing image: %w", err))
+		// mz992: a dryrun renders the plan and returns no image, there is nothing to push.
+		if !opts.Dryrun {
+			if err := executor.DoPush(image, opts); err != nil {
+				exit(fmt.Errorf("error pushing image: %w", err))
+			}
 		}
 		tracing.Shutdown(nil)
 	},

--- a/integration/dockerfiles/Dockerfile_test_issue_mz473
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz473
@@ -5,9 +5,4 @@ FROM ${IMAGE_REPO}busybox
 # When running kaniko with KANIKO_DIR=/kaniko2 in order to relocate the binary,
 # The binary would simply get deleted instead.
 # Verify here that relocation indeed works.
-RUN if ls -l /proc/1/exe | grep -q '/kaniko/executor'; then \
-        [ ! -d /kaniko ]; \
-        [ -f /kaniko2/executor ]; \
-    else \
-        echo "PID1 is not Kaniko, skipping check"; \
-    fi
+RUN [ ! -d /kaniko ] && [ -f /kaniko2/executor ]

--- a/integration/dockerfiles/Dockerfile_test_issue_mz992
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz992
@@ -1,0 +1,9 @@
+# mz992: --dryrun prints the plan and then panics if a real --destination is set.
+# Panics on v1.28.2.
+# DoBuild returns a nil image for a dryrun, DoPush skips the push for --no-push
+# only and dereferences it. The destination push, the digest files, the tarball
+# and the OCI layout all crash.
+# The golden suite misses this, it calls DoBuild directly and never reaches DoPush.
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}busybox
+RUN echo mz992

--- a/integration/images.go
+++ b/integration/images.go
@@ -144,7 +144,6 @@ var additionalDockerFlagsMap = map[string][]string{
 	"Dockerfile_test_target":                       {"--target=second"},
 	"Dockerfile_test_issue_cg188":                  {"--secret=id=netrc,env=SECRET"},
 	"Dockerfile_test_issue_mz511":                  {"--secret=id=netrc,src=context/foo"},
-	"Dockerfile_test_issue_mz661":                  {"--secret=id=kaniko,src=context/foo"},
 	"Dockerfile_test_cross_compile":                {"--platform=linux/" + crossCompileArch},
 	"Dockerfile_test_issue_mz849":                  dockerV2Flags,
 	"Dockerfile_test_issue_mz849_dockerv2":         dockerV2Flags,
@@ -241,6 +240,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_issue_mz529":   {"--cleanup", "--target=final,nosquash"},
 	"Dockerfile_test_issue_mz595":   {"--cleanup"},
 	"Dockerfile_test_issue_mz661":   {"--secret=id=kaniko,src=/kaniko/executor"},
+	"Dockerfile_test_issue_mz992":   {"--dryrun", "--tar-path=/kaniko/dryrun.tar", "--oci-layout-path=/kaniko/dryrun-layout"},
 }
 
 var expectErr = map[string]int{
@@ -321,8 +321,6 @@ var diffArgsMap = map[string][]string{
 	"TestRun/test_Dockerfile_test_issue_cg188":               {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_issue_mz247":               {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_issue_mz332":               {"--extra-ignore-layer-length-mismatch"},
-	"TestRun/test_Dockerfile_test_issue_mz455":               {"--extra-ignore-layer-length-mismatch"},
-	"TestRun/test_Dockerfile_test_issue_mz560":               {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_issue_mz725":               {"--extra-ignore-layer-length-mismatch"},
 	"TestWithContext/test_with_context_issue-57":             {"--extra-ignore-layer-length-mismatch"},
 	"TestWithContext/test_with_context_issue-1568":           {"--extra-ignore-layer-length-mismatch"},
@@ -512,6 +510,7 @@ type DockerFileBuilder struct {
 	TestOCICacheDockerfiles     map[string]struct{}
 	TestWarmerDockerfiles       map[string]struct{}
 	TestReproducibleDockerfiles map[string]struct{}
+	TestKanikoOnlyDockerfiles   map[string]struct{}
 }
 
 type logger func(string, ...any)
@@ -564,6 +563,17 @@ func NewDockerFileBuilder() *DockerFileBuilder {
 		"Dockerfile_test_copy_reproducible": {},
 		"Dockerfile_test_issue_mz731":       {},
 		"Dockerfile_test_issue_mz851":       {},
+	}
+	d.TestKanikoOnlyDockerfiles = map[string]struct{}{
+		"Dockerfile_test_issue_cg326_2": {},
+		"Dockerfile_test_issue_cg326_3": {},
+		"Dockerfile_test_issue_mz444":   {},
+		"Dockerfile_test_issue_mz455":   {},
+		"Dockerfile_test_issue_mz473":   {},
+		"Dockerfile_test_issue_mz560":   {},
+		"Dockerfile_test_issue_mz661":   {},
+		"Dockerfile_test_issue_mz753":   {},
+		"Dockerfile_test_issue_mz992":   {},
 	}
 	return &d
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -223,6 +223,9 @@ func TestRun(t *testing.T) {
 			if _, ok := imageBuilder.TestReproducibleDockerfiles[dockerfile]; ok {
 				t.SkipNow()
 			}
+			if _, ok := imageBuilder.TestKanikoOnlyDockerfiles[dockerfile]; ok {
+				t.SkipNow()
+			}
 
 			buildImage(t, dockerfile, imageBuilder)
 
@@ -230,6 +233,25 @@ func TestRun(t *testing.T) {
 			kanikoImage := GetKanikoImage(config.imageRepo, dockerfile)
 
 			containerDiff(t, dockerImage, kanikoImage, "--semantic", "--extra-ignore-file-content")
+		})
+	}
+}
+
+// TestKanikoOnly asserts kaniko survives the build.
+func TestKanikoOnly(t *testing.T) {
+	t.Parallel()
+	for dockerfile := range imageBuilder.TestKanikoOnlyDockerfiles {
+		if match, _ := filepath.Match(config.dockerfilesPattern, dockerfile); !match {
+			continue
+		}
+		t.Run("test_"+dockerfile, func(t *testing.T) {
+			dockerfile := dockerfile
+			t.Parallel()
+
+			err := imageBuilder.BuildKanikoImage(t, config, dockerfilesPath, dockerfile)
+			if err != nil {
+				t.Fatal(err)
+			}
 		})
 	}
 }
@@ -674,6 +696,9 @@ func TestLayers(t *testing.T) {
 				t.SkipNow()
 			}
 			if _, ok := expectErr[dockerfile]; ok {
+				t.SkipNow()
+			}
+			if _, ok := imageBuilder.TestKanikoOnlyDockerfiles[dockerfileTest]; ok {
 				t.SkipNow()
 			}
 

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -36,6 +36,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/osscontainertools/kaniko/pkg/assert"
 	"github.com/osscontainertools/kaniko/pkg/cache"
 	"github.com/osscontainertools/kaniko/pkg/config"
 	"github.com/osscontainertools/kaniko/pkg/constants"
@@ -177,8 +178,11 @@ func writeDigestFile(path string, digestByteArray []byte) error {
 // A dummy destination would be set when --no-push is set to true and --tar-path
 // is not empty with empty --destinations.
 func DoPush(image v1.Image, opts *config.KanikoOptions) error {
+	assert.Assert("executor.push.image-nonnull", image != nil, "DoPush called with nil image")
+
 	t := timing.Start("Total Push Time")
 	defer t.End()
+
 	var digestByteArray []byte
 	var builder strings.Builder
 


### PR DESCRIPTION
Fixes #992

A dryrun renders the plan and builds nothing, so `DoBuild` returns a nil image. `DoPush` only skipped the push for `--no-push`, so it dereferenced that nil image and the executor panicked right after printing a complete plan. Combining `--dryrun` with a real destination is the natural way to preview what a build will push, and it was the one combination that crashed. The push is not the only path that dereferenced the image, the digest files, the tarball and the OCI layout do too. The nil image is how `DoBuild` signals plan-only, so the caller that reads that convention is the one that skips the push, and `DoPush` asserts a non-nil image instead of quietly tolerating one.

The golden suite passes `--dryrun` but calls `DoBuild` directly and never reaches `DoPush`, which is why nothing caught this. The repro therefore needs a real executor run, and it has no docker counterpart, so it comes with `TestKanikoOnly`, a suite for scenarios that live inside kaniko itself and have no oracle to diff against. Several existing tests were being shoehorned into docker parity for want of such a home, either carrying diffoci ignores that only existed to make a meaningless comparison pass, or asking `/proc/1/exe` at build time whether kaniko was the builder so the docker side would pass vacuously. Those move over here and shed the workarounds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Dry-run executions no longer attempt to push images, preventing related failures.
  - Image push operations now provide a clear error when no image is available.
  - Improved handling of Kaniko-only integration scenarios and dry-run builds.

- **Tests**
  - Added coverage for dry-run panic prevention, tar output, and OCI layout generation.
  - Kaniko-only image builds are now tested separately from Docker-based builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->