### PR TITLE
mz991: snapshot at the last command that runs

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz991
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz991
@@ -1,0 +1,15 @@
+ARG IMAGE_REPO
+# mz991: --single-snapshot with a trailing MAINTAINER discards the whole stage.
+# Broken since v1.27.6. base loses /marker from the image it saves for final,
+# final loses /marker2 from the pushed image, and nosquash holds no runnable
+# command at all.
+FROM ${IMAGE_REPO}busybox AS base
+RUN echo marker > /marker
+MAINTAINER someone
+
+FROM base AS nosquash
+MAINTAINER someone
+
+FROM base AS final
+RUN echo marker2 > /marker2
+MAINTAINER someone

--- a/integration/images.go
+++ b/integration/images.go
@@ -207,6 +207,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_issue_mz775":                {"--compressed-caching=false", "--target=final,nosquash"},
 	"Dockerfile_test_add":                        {"--single-snapshot"},
 	"Dockerfile_test_issue_mz621":                {"--single-snapshot"},
+	"Dockerfile_test_issue_mz991":                {"--single-snapshot", "--target=final,nosquash"},
 	"Dockerfile_test_run_new":                    {"--use-new-run=true"},
 	"Dockerfile_test_run_redo":                   {"--snapshot-mode=redo"},
 	"Dockerfile_test_scratch":                    {"--single-snapshot"},
@@ -410,6 +411,9 @@ var expectedWarnings = map[string]string{
 	"Dockerfile_test_issue_mz793": "feature flags explicitly disabled, please create an issue for your use-case: FF_KANIKO_VOLUME_SKIP_MKDIR",
 	// mz936: the read-only store makes both stages degrade to a registry fetch, each warning.
 	"Dockerfile_test_issue_mz936": "shared-base:",
+	// mz991: the repro needs a MAINTAINER, which warns twice, once from the buildkit
+	// linter and once from kaniko skipping the command. Both lines say "is deprecated".
+	"Dockerfile_test_issue_mz991": "is deprecated",
 }
 
 func checkNoWarnings(dockerfile string, out []byte) error {

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -582,6 +582,16 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 		initSnapshotTaken = true
 	}
 
+	// mz991: s.cmds keeps a nil for every MAINTAINER so its positions stay aligned
+	// with stage.Commands, so the last entry is not always the last command to run.
+	lastRunnableIdx := -1
+	for i, cmd := range slices.Backward(s.cmds) {
+		if cmd != nil {
+			lastRunnableIdx = i
+			break
+		}
+	}
+
 	cacheGroup := errgroup.Group{}
 	var cmdTimer trace.Span
 	// stop on the way out too: an unended span is never exported
@@ -691,7 +701,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 		cmdTimer.End()
 		cmdTimer = nil
 
-		isLastCommand := index == len(s.cmds)-1
+		isLastCommand := index == lastRunnableIdx
 		if !shouldTakeSnapshot(command.MetadataOnly(), isLastCommand, opts) {
 			logrus.Debugf("Build: skipping snapshot for [%v]", command.String())
 			continue


### PR DESCRIPTION
Fixes #991

`--single-snapshot` takes its one snapshot at the last command of the stage, and the test for that was `index == len(s.cmds)-1`. Since PR #674 a MAINTAINER leaves a nil in `s.cmds` so positions stay aligned with `stage.Commands`, which `cacheKeys`, `redirectKeys` and `s.lines` index by. When the trailing entry is that nil, the only index that satisfies the test is the one the build loop skips, so no command is ever the last one, nothing is snapshotted, and the stage is discarded. The build succeeds and pushes base layers only. A downstream `FROM <stage>` inherits the damage, because the stage is saved without its layer.

So compare against the last entry that will actually run instead of the last entry. That keeps every index the cache keys and line numbers depend on where it is. Dropping the nils in `newStageBuilder` would be shorter but renumbers `s.cmds` against `stage.Commands`.

Not gated behind a feature flag. Releases up to v1.27.5 snapshotted these builds correctly, so this restores behavior rather than introducing it, and a default-off flag would leave the silent data loss in place for exactly the users who cannot know the flag exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed single-snapshot builds that include trailing metadata instructions.
  * Ensured the correct filesystem snapshot is captured when non-executable instructions appear at the end of a build stage.
  * Improved build reliability across multiple target stages.
  * Added coverage for the issue and its associated deprecation warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->