### PR TITLE
tracing: append the OTLP signal path to a path-less endpoint

### DIFF
--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -23,6 +23,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -73,6 +74,18 @@ func spanLimits() sdktrace.SpanLimits {
 	return limits
 }
 
+// otlptracehttp >= 1.45 no longer appends the OTLP signal path itself.
+func tracesEndpoint(endpoint string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return endpoint
+	}
+	if u.Path != "" && u.Path != "/" {
+		return endpoint
+	}
+	return u.JoinPath("/v1/traces").String()
+}
+
 func Init(ctx context.Context, opts *config.KanikoOptions) {
 	endpoint := os.Getenv(EndpointEnv)
 	if endpoint == "" {
@@ -81,7 +94,7 @@ func Init(ctx context.Context, opts *config.KanikoOptions) {
 	if strings.HasPrefix(endpoint, "http://") {
 		logrus.Warnf("%s uses plaintext http: spans (including Dockerfile content) are sent unencrypted", EndpointEnv)
 	}
-	exp, err := otlptracehttp.New(ctx, otlptracehttp.WithEndpointURL(endpoint))
+	exp, err := otlptracehttp.New(ctx, otlptracehttp.WithEndpointURL(tracesEndpoint(endpoint)))
 	if err != nil {
 		logrus.Debugf("tracing disabled: failed to create OTLP exporter: %v", err)
 		return


### PR DESCRIPTION
`otlptracehttp` 1.45.0 changed `WithEndpointURL`: a URL with no path now targets the root path instead of having `/v1/traces` appended. Upstream calls this out as a breaking change (open-telemetry/opentelemetry-go#8538), aligning it with `otlploghttp` and with `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.

We document `KANIKO_TELEMETRY_ENDPOINT` as a collector base URL (`README.md`, `docs/telemetry.md`), so every path-less endpoint started POSTing to `/` and getting a 404. Nothing failed: the export error only reaches OTel's global error handler, never logrus, so builds kept passing while emitting no traces. Our own CI stopped delivering spans the moment #996 merged and nobody noticed for 11 hours.

Appending the path only when the endpoint carries none keeps both forms working, so an endpoint that already ends in `/v1/traces` is not doubled.

Verified end-to-end against a real collector + ClickHouse, with a build run through the executor:

| `KANIKO_TELEMETRY_ENDPOINT` | before | after |
| --- | --- | --- |
| `http://host:4318` | `404 Not Found`, 0 spans | 9 spans, root span present |
| `http://host:4318/v1/traces` | 9 spans | 9 spans |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTLP tracing endpoint handling by automatically appending the required `/v1/traces` path when no specific path is provided.
  * Preserved existing custom endpoint paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->