### PR TITLE
Let the nightly scan fail instead of filing an issue

### DIFF
--- a/.github/workflows/nightly-vulnerability-scan.yml
+++ b/.github/workflows/nightly-vulnerability-scan.yml
@@ -12,7 +12,6 @@ jobs:
 
     permissions:
       packages: read # pull image from ghcr registry
-      issues: write # create issues via gh CLI
 
     runs-on: ubuntu-24.04
 
@@ -59,12 +58,4 @@ jobs:
         run: |
           IMAGE_ID="ghcr.io/${{ github.repository }}-dev:${{ steps.get-commit.outputs.sha }}"
           echo "Scanning image $IMAGE_ID"
-          grype $IMAGE_ID > grype-output.txt
-
-      - name: Check for vulnerabilities and create an issue
-        run: |
-          if grep -q 'No vulnerabilities found' grype-output.txt; then
-            echo "No vulnerabilities found."
-          else
-            gh issue create --title "Vulnerabilities Found in Nightly Scan" --body "Vulnerabilities found in the latest image scan. Please check the attached report." --body-file grype-output.txt
-          fi
+          grype "$IMAGE_ID" --fail-on negligible


### PR DESCRIPTION
The nightly has been red for eight nights and it was never about vulnerabilities. Grype runs fine, the issue step is what fails: `gh` exits 4 with no token in its env, and it passes `--body` and `--body-file` together, which gh rejects. So we got a red run every morning, no issue ever, and the grype report went into a file nobody reads.

Issue filing is gone, a failed run mails whoever last touched the cron and that is enough. `issues: write` dropped with it.

grype now gates itself and prints the report to the log. No severity floor, we scan a scratch image so there is no distro package database to produce noise and anything found is in our own binaries or in busybox. `negligible` is the lowest the flag takes, grype rejects `unknown` outright, so matches that carry no severity at all still would not trip it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Automated vulnerability scans now fail when any vulnerability is detected, including negligible-severity issues.
  * Scan results remain available in workflow logs for review.
  * Removed automatic vulnerability report file generation and issue creation.
  * Reduced automation permissions used during vulnerability scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->