### PR TITLE
run the integration TLS registry behind a token auth server

### DIFF
--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -19,21 +19,35 @@ function start_local_registry {
   docker start registry 2>/dev/null || docker run --name registry -d -p 5000:5000 registry:2
 }
 
-function start_local_tls_registry {
+function start_local_auth_server {
   local dir="/tmp/kaniko-tls-registry"
   "$(dirname "$0")/setup-tls-registry-creds.sh"
+  if ! docker start kaniko-auth-server 2>/dev/null; then
+    docker rm -f kaniko-auth-server 2>/dev/null || true
+    docker run -d --name kaniko-auth-server \
+      -p 5002:5002 \
+      -v "${dir}/tls.crt:/certs/tls.crt:ro" \
+      -v "${dir}/tls.key:/certs/tls.key:ro" \
+      -v "${dir}/auth_config.yml:/config/auth_config.yml:ro" \
+      cesanta/docker_auth:1 /config/auth_config.yml
+  fi
+}
+
+function start_local_tls_registry {
+  local dir="/tmp/kaniko-tls-registry"
   if ! docker start kaniko-tls-registry 2>/dev/null; then
     docker rm -f kaniko-tls-registry 2>/dev/null || true
     docker run -d --name kaniko-tls-registry \
       -p 127.0.0.2:5001:5000 \
       -v "${dir}/tls.crt:/certs/tls.crt:ro" \
       -v "${dir}/tls.key:/certs/tls.key:ro" \
-      -v "${dir}/htpasswd:/auth/htpasswd:ro" \
       -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/tls.crt \
       -e REGISTRY_HTTP_TLS_KEY=/certs/tls.key \
-      -e REGISTRY_AUTH=htpasswd \
-      -e REGISTRY_AUTH_HTPASSWD_REALM=Registry \
-      -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
+      -e REGISTRY_AUTH=token \
+      -e REGISTRY_AUTH_TOKEN_REALM=https://localhost:5002/auth \
+      -e REGISTRY_AUTH_TOKEN_SERVICE=kaniko-test-registry \
+      -e REGISTRY_AUTH_TOKEN_ISSUER=kaniko-test-auth \
+      -e REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE=/certs/tls.crt \
       registry:2
   fi
 }
@@ -58,6 +72,7 @@ fi
 if [[ -n ${LOCAL} ]]; then
   echo "running in local mode, mocking registry..."
   start_local_registry
+  start_local_auth_server
   start_local_tls_registry
 
   IMAGE_REPO="localhost:5000"

--- a/scripts/k3s-setup.sh
+++ b/scripts/k3s-setup.sh
@@ -33,18 +33,20 @@ kubectl create secret tls local-tls-registry-cert \
   --key="${TLS_REG_DIR}/tls.key" \
   --dry-run=client -o yaml | kubectl apply -f -
 
-kubectl create secret generic local-tls-registry-auth \
+kubectl create secret generic local-auth-server-config \
   -n kube-system \
-  --from-file=htpasswd="${TLS_REG_DIR}/htpasswd" \
+  --from-file=auth_config.yml="${TLS_REG_DIR}/auth_config.yml" \
   --dry-run=client -o yaml | kubectl apply -f -
 
 # Install local registry and have it listen on localhost:5000
 sudo cp "${SCRIPT_PATH}/local-registry-helm.yaml" /var/lib/rancher/k3s/server/manifests/
+sudo cp "${SCRIPT_PATH}/local-auth-server.yaml" /var/lib/rancher/k3s/server/manifests/
 # Wait until both helm chart installs complete
 timeout 10m bash -c 'until kubectl get -n kube-system pod 2>/dev/null | grep "^helm-install-local-registry-" | grep -v tls | grep Completed >/dev/null; do sleep 1; done'
 timeout 10m bash -c 'until kubectl get -n kube-system pod 2>/dev/null | grep "^helm-install-local-tls-registry-" | grep Completed >/dev/null; do sleep 1; done'
 # Wait until registry becomes available on localhost:5000
 timeout 5m bash -c 'until nc -z localhost 5000; do sleep 1; done'
+timeout 5m bash -c 'until nc -z localhost 5002; do sleep 1; done'
 timeout 5m bash -c 'until nc -z 127.0.0.2 5001; do sleep 1; done'
 
 echo "K3s is running and registry is available on localhost:5000"

--- a/scripts/local-auth-server.yaml
+++ b/scripts/local-auth-server.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-auth-server
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-auth-server
+  template:
+    metadata:
+      labels:
+        app: local-auth-server
+    spec:
+      containers:
+        - name: auth-server
+          image: cesanta/docker_auth:1
+          args: ["/config/auth_config.yml"]
+          ports:
+            - containerPort: 5002
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+      volumes:
+        - name: config
+          secret:
+            secretName: local-auth-server-config
+        - name: certs
+          secret:
+            secretName: local-tls-registry-cert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: local-auth-server
+  namespace: kube-system
+spec:
+  type: LoadBalancer
+  selector:
+    app: local-auth-server
+  ports:
+    - port: 5002
+      targetPort: 5002

--- a/scripts/local-registry-helm.yaml
+++ b/scripts/local-registry-helm.yaml
@@ -23,18 +23,22 @@ spec:
     tlsSecretName: local-tls-registry-cert
     extraEnvVars:
       - name: REGISTRY_AUTH
-        value: htpasswd
-      - name: REGISTRY_AUTH_HTPASSWD_REALM
-        value: "Registry Realm"
-      - name: REGISTRY_AUTH_HTPASSWD_PATH
-        value: /auth/htpasswd
+        value: token
+      - name: REGISTRY_AUTH_TOKEN_REALM
+        value: https://localhost:5002/auth
+      - name: REGISTRY_AUTH_TOKEN_SERVICE
+        value: kaniko-test-registry
+      - name: REGISTRY_AUTH_TOKEN_ISSUER
+        value: kaniko-test-auth
+      - name: REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE
+        value: /auth/tls.crt
     extraVolumes:
       - name: auth
         secret:
-          secretName: local-tls-registry-auth
+          secretName: local-tls-registry-cert
           items:
-            - key: htpasswd
-              path: htpasswd
+            - key: tls.crt
+              path: tls.crt
     extraVolumeMounts:
       - name: auth
         mountPath: /auth

--- a/scripts/setup-tls-registry-creds.sh
+++ b/scripts/setup-tls-registry-creds.sh
@@ -18,18 +18,47 @@ set -euo pipefail
 TLS_REG_DIR="/tmp/kaniko-tls-registry"
 mkdir -p "${TLS_REG_DIR}"
 
-if [[ ! -f "${TLS_REG_DIR}/tls.crt" ]]; then
+# ggcr refuses a token realm on a loopback IP literal, so the auth server is reached
+# under the name localhost and the cert has to cover it.
+if [[ ! -f "${TLS_REG_DIR}/tls.crt" ]] || ! openssl x509 -in "${TLS_REG_DIR}/tls.crt" -noout -text | grep -q "DNS:localhost"; then
   openssl req -x509 -newkey rsa:2048 \
     -keyout "${TLS_REG_DIR}/tls.key" \
     -out "${TLS_REG_DIR}/tls.crt" \
     -days 3650 -nodes \
     -subj "/CN=127.0.0.2" \
-    -addext "subjectAltName=IP:127.0.0.2" \
+    -addext "subjectAltName=IP:127.0.0.2,DNS:localhost" \
     2>/dev/null
 fi
 
-if [[ ! -f "${TLS_REG_DIR}/htpasswd" ]]; then
-  # kanikotest:kanikotest
-  docker run --rm --entrypoint htpasswd httpd:2 -Bbn kanikotest kanikotest \
-    > "${TLS_REG_DIR}/htpasswd"
+function bcrypt {
+  docker run --rm --entrypoint htpasswd httpd:2 -Bbn "$1" "$1" | cut -d: -f2-
+}
+
+if [[ ! -f "${TLS_REG_DIR}/auth_config.yml" ]]; then
+  cat > "${TLS_REG_DIR}/auth_config.yml" <<EOF
+server:
+  addr: ":5002"
+  certificate: /certs/tls.crt
+  key: /certs/tls.key
+
+token:
+  issuer: kaniko-test-auth
+  expiration: 900
+
+users:
+  kanikotest:
+    password: "$(bcrypt kanikotest)"
+  usera:
+    password: "$(bcrypt usera)"
+  userb:
+    password: "$(bcrypt userb)"
+
+acl:
+  - match: {account: kanikotest}
+    actions: ["*"]
+  - match: {account: usera, name: "/^usera\\\\/.*/"}
+    actions: ["*"]
+  - match: {account: userb, name: "/^userb\\\\/.*/"}
+    actions: ["*"]
+EOF
 fi


### PR DESCRIPTION
The integration suite has an authenticated registry, but htpasswd authorizes every valid user for every repository, so it cannot express per-repository credentials at all. That is exactly what #1008 is about, and what #1002 needs to test. This puts cesanta/docker_auth in front of the TLS registry and switches it to token auth, so the ACL can grant usera its own namespace and userb only its own. A test can then tell which credential kaniko actually sent, instead of only whether it sent one.

kanikotest keeps access to every repository, so the existing TLS test is unaffected.

The auth realm is reached as localhost rather than 127.0.0.2 because ggcr rejects a token realm whose host is a loopback or private IP literal. The cert now carries a DNS:localhost SAN alongside the address, and certs generated before that are regenerated instead of failing later with a confusing TLS error.

No test uses usera or userb yet. That comes with the fix in #1014.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a local authentication service for secure container registry access.
  - Local registry authentication now uses token-based credentials with configurable access permissions.
  - Local Kubernetes setup automatically deploys and waits for the authentication service.

- **Bug Fixes**
  - Improved local TLS certificate generation to include `localhost` and `127.0.0.2`, regenerating certificates when required.
  - Simplified local integration testing by automatically starting the authentication service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->