### PR TITLE
tracing: associate every span with its stage and command

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -36,6 +36,7 @@ import (
 	"github.com/osscontainertools/kaniko/pkg/constants"
 	"github.com/osscontainertools/kaniko/pkg/executor"
 	"github.com/osscontainertools/kaniko/pkg/logging"
+	"github.com/osscontainertools/kaniko/pkg/timing"
 	"github.com/osscontainertools/kaniko/pkg/tracing"
 	"github.com/osscontainertools/kaniko/pkg/util"
 	"github.com/osscontainertools/kaniko/pkg/util/proc"
@@ -238,7 +239,10 @@ var RootCmd = &cobra.Command{
 		}
 		// mz992: a dryrun renders the plan and returns no image, there is nothing to push.
 		if !opts.Dryrun {
-			if err := executor.DoPush(image, opts); err != nil {
+			t := timing.Start("Total Push Time")
+			err := executor.DoPush(image, opts)
+			t.End()
+			if err != nil {
 				exit(fmt.Errorf("error pushing image: %w", err))
 			}
 		}

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -233,15 +233,17 @@ var RootCmd = &cobra.Command{
 			}()
 		}
 		tracing.Init(context.Background(), opts)
+		_, endBuild := timing.Scope("Total Build Time")
 		image, err := executor.DoBuild(opts)
+		endBuild()
 		if err != nil {
 			exit(fmt.Errorf("error building image: %w", err))
 		}
 		// mz992: a dryrun renders the plan and returns no image, there is nothing to push.
 		if !opts.Dryrun {
-			t := timing.Start("Total Push Time")
+			pushTimer := timing.Start("Total Push Time")
 			err := executor.DoPush(image, opts)
-			t.End()
+			pushTimer.End()
 			if err != nil {
 				exit(fmt.Errorf("error pushing image: %w", err))
 			}

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -8,7 +8,7 @@ KANIKO_TELEMETRY_ENDPOINT=http://otel-collector:4318
 
 Spans are sent over OTLP/HTTP (`http://` or `https://`, collector port 4318 by default). OTLP/gRPC (port 4317) is not supported. The endpoint URL must include a scheme. `OTEL_EXPORTER_OTLP_HEADERS` authenticates to the collector and `OTEL_RESOURCE_ATTRIBUTES` adds fleet labels such as `tenant`, `repo`, and `git.sha`.
 
-Each build is one trace: a root `build` span plus a span per build phase and Dockerfile command. Command spans are named `Command` (low cardinality, so backends can aggregate on the name). The full instruction text is in the `kaniko.command` attribute. The build phases keep their descriptive names.
+Each build is one trace: a root `build` span, a `Stage` span per build stage, and under each stage a span per build phase and Dockerfile command. Stage and command spans are named `Stage` and `Command` (low cardinality, so backends can aggregate on the name). The full instruction text is in the `kaniko.command` attribute. The build phases keep their descriptive names.
 
 Set `KANIKO_TELEMETRY_OMIT_DOCKERFILE=true` to keep the Dockerfile source out of the trace.
 
@@ -36,13 +36,19 @@ Attribute values are capped at 64 KiB. `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` 
 | `kaniko.registry.dial.ms` | time spent opening connections |
 | `kaniko.registry.idle.ms` | total time connections sat idle before being reused |
 
+## Stage spans
+
+| Attribute | Value |
+| --- | --- |
+| `kaniko.stage` | stage index (integer) |
+| `kaniko.stage.name` | stage name from `FROM ... AS <name>`, empty for unnamed stages |
+
 ## Command spans
 
 | Attribute | Value |
 | --- | --- |
 | `kaniko.command` | full instruction text |
 | `kaniko.command.hash` | hash of the stage index and command text |
-| `kaniko.phase` | `kaniko`, `build`, or `network` |
 | `kaniko.instruction.index` | command index within the stage |
 | `kaniko.instruction.line` | source line in the Dockerfile |
 | `kaniko.stage` | stage index (integer) |
@@ -51,5 +57,4 @@ Attribute values are capped at 64 KiB. `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` 
 
 ## Phases
 
-`kaniko.phase` is `network`, `build` or `kaniko`, and follows the span name. `FS Unpacking` reports `kaniko` even though extraction pulls the layers off the registry when nothing has them locally, so its transfer time is not visible as networking yet.
-
+`kaniko.phase` is `network`, `build` or `kaniko`, and follows the span name.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -49,3 +49,7 @@ Attribute values are capped at 64 KiB. `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` 
 | `kaniko.cache.hit` | `true` when the command was replayed from cache (only with `--cache`, absent when caching is off) |
 | `kaniko.cache.key` | cache key for the command (only with `--cache`) |
 
+## Phases
+
+`kaniko.phase` is `network`, `build` or `kaniko`, and follows the span name. `FS Unpacking` reports `kaniko` even though extraction pulls the layers off the registry when nothing has them locally, so its transfer time is not visible as networking yet.
+

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -86,6 +86,10 @@ type stageBuilder struct {
 	cmds            []commands.DockerCommand
 	lines           []int // source line per command, aligned with cmds
 	args            *dockerfile.BuildArgs
+	// span is the stage's own span. Work that belongs to the stage rather than to
+	// one of its commands names it as parent, and so does anything handed to a
+	// goroutine, which cannot rely on the scope stack.
+	span trace.Span
 }
 
 type stageCacheInfo struct {
@@ -595,19 +599,31 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 	}
 
 	cacheGroup := errgroup.Group{}
+	// One span per command, covering everything that command causes: its cache
+	// key, its execution and its snapshot. Closing it at the top of the next
+	// iteration and on the way out keeps every exit path covered, and an unended
+	// span is never exported.
 	var cmdTimer trace.Span
-	// stop on the way out too: an unended span is never exported
-	defer func() {
+	var cmdScope func()
+	endCmd := func() {
+		if cmdScope != nil {
+			cmdScope()
+			cmdScope = nil
+		}
 		if cmdTimer != nil {
 			cmdTimer.End()
+			cmdTimer = nil
 		}
-	}()
+	}
+	defer endCmd()
 	for index, command := range s.cmds {
+		endCmd()
 		if command == nil {
 			continue
 		}
 
 		cmdTimer = timing.Start("Command")
+		cmdScope = timing.Scope(cmdTimer)
 
 		// mz334: cross-stage copies key off the inferred pointer first, their
 		// source stage may be eliminated and its files never materialize. The
@@ -687,7 +703,9 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 		if !initSnapshotTaken && !isCacheCommand && !command.ProvidesFilesToSnapshot() {
 			// Take initial snapshot if command does not expect to return
 			// a list of files.
-			t := timing.StartChild(cmdTimer, "Initial FS snapshot")
+			// Stage setup, taken once for whichever command first needs it, so it
+			// belongs to the stage rather than to that arbitrary command.
+			t := timing.StartChild(s.span, "Initial FS snapshot")
 			err := snapshotter.Init()
 			t.End()
 			if err != nil {
@@ -696,15 +714,13 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 			initSnapshotTaken = true
 		}
 
-		execTimer := timing.StartChild(cmdTimer, "Execute")
+		execTimer := timing.Start("Execute")
 		err := command.ExecuteCommand(&s.cf.Config, s.args)
 		execTimer.End()
 		if err != nil {
 			return fmt.Errorf("failed to execute command: %w", err)
 		}
 		files = command.FilesToSnapshot()
-		cmdTimer.End()
-		cmdTimer = nil
 
 		isLastCommand := index == lastRunnableIdx
 		if !shouldTakeSnapshot(command.MetadataOnly(), isLastCommand, opts) {
@@ -756,7 +772,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 				// Push layer to cache (in parallel) now along with new config file
 				if command.ShouldCacheOutput() && !opts.NoPushCache {
 					cacheGroup.Go(func() error {
-						return pushCache(opts, ck, tarPath, command.String())
+						return pushCache(opts, ck, tarPath, command.String(), s.span)
 					})
 					// mz334: also push a pointer under the inferred key so that a
 					// subsequent optimize pass can find the content key and continue
@@ -769,7 +785,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 						}
 						assert.Assert("executor.build.key-hash", h == ck, "rawCompositeKey hash %v does not match ck %v", h, ck)
 						cacheGroup.Go(func() error {
-							return pushPointer(opts, inferredCacheKey, rawKey)
+							return pushPointer(opts, inferredCacheKey, rawKey, s.span)
 						})
 					}
 				}
@@ -781,6 +797,10 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 		}
 	}
 
+	// The stage waits for the uploads its commands kicked off, so close the last
+	// command first: the wait is the stage's, not that command's. It needs no span
+	// of its own, the layer pushes already cover the window it blocks on.
+	endCmd()
 	if err := cacheGroup.Wait(); err != nil {
 		logrus.Warnf("Error uploading layer to cache: %s", err)
 	}
@@ -1491,6 +1511,25 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		}
 	}
 
+	// One span per stage, so fetching its base, unpacking it and every command it
+	// runs hang off the stage they belong to. Same close-on-next-iteration shape
+	// as the command spans, which covers the error returns below. Deferred before
+	// the cleanup below so LIFO order closes the final stage only after the
+	// filesystem cleanup has run inside its span.
+	var stageSpan trace.Span
+	var stageScope func()
+	endStage := func() {
+		if stageScope != nil {
+			stageScope()
+			stageScope = nil
+		}
+		if stageSpan != nil {
+			stageSpan.End()
+			stageSpan = nil
+		}
+	}
+	defer endStage()
+
 	if opts.Cleanup {
 		defer assignIfNil(&retErr, func() error {
 			if err = util.DeleteFilesystem(); err != nil {
@@ -1512,6 +1551,14 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 
 	var pushImage v1.Image
 	for _, stage := range kanikoStages {
+		endStage()
+		stageSpan = timing.Start("Stage")
+		stageSpan.SetAttributes(
+			attribute.Int("kaniko.stage", stage.Index),
+			attribute.String("kaniko.stage.name", stage.Name),
+		)
+		stageScope = timing.Scope(stageSpan)
+
 		baseImage, err := retrieveBaseImage(stage, opts, sharedRemote[stage.BaseImageDigest])
 		if err != nil {
 			return nil, fmt.Errorf("failed to get baseImage: %w", err)
@@ -1532,6 +1579,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		if err != nil {
 			return nil, err
 		}
+		sb.span = stageSpan
 		logrus.Infof("Building stage '%v' [idx: '%v', base-idx: '%v']",
 			stage.BaseName, stage.Index, stage.BaseImageIndex)
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -86,10 +86,7 @@ type stageBuilder struct {
 	cmds            []commands.DockerCommand
 	lines           []int // source line per command, aligned with cmds
 	args            *dockerfile.BuildArgs
-	// span is the stage's own span. Work that belongs to the stage rather than to
-	// one of its commands names it as parent, and so does anything handed to a
-	// goroutine, which cannot rely on the scope stack.
-	span trace.Span
+	span            trace.Span
 }
 
 type stageCacheInfo struct {
@@ -599,31 +596,38 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 	}
 
 	cacheGroup := errgroup.Group{}
-	// One span per command, covering everything that command causes: its cache
-	// key, its execution and its snapshot. Closing it at the top of the next
-	// iteration and on the way out keeps every exit path covered, and an unended
-	// span is never exported.
-	var cmdTimer trace.Span
-	var cmdScope func()
-	endCmd := func() {
-		if cmdScope != nil {
-			cmdScope()
-			cmdScope = nil
-		}
-		if cmdTimer != nil {
-			cmdTimer.End()
-			cmdTimer = nil
-		}
-	}
-	defer endCmd()
+	endCmd := func() {}
+	// stop on the way out too: an unended span is never exported
+	defer func() { endCmd() }()
 	for index, command := range s.cmds {
 		endCmd()
 		if command == nil {
 			continue
 		}
 
-		cmdTimer = timing.Start("Command")
-		cmdScope = timing.Scope(cmdTimer)
+		isCacheCommand := func() bool {
+			switch command.(type) {
+			case commands.Cached:
+				return true
+			default:
+				return false
+			}
+		}()
+
+		if !initSnapshotTaken && !isCacheCommand && !command.ProvidesFilesToSnapshot() {
+			// Take initial snapshot if command does not expect to return
+			// a list of files.
+			t := timing.Start("Initial FS snapshot")
+			err := snapshotter.Init()
+			t.End()
+			if err != nil {
+				return err
+			}
+			initSnapshotTaken = true
+		}
+
+		cmdTimer, closeCmd := timing.Scope("Command")
+		endCmd = closeCmd
 
 		// mz334: cross-stage copies key off the inferred pointer first, their
 		// source stage may be eliminated and its files never materialize. The
@@ -668,25 +672,10 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 
 		logrus.Info(command.String())
 
-		isCacheCommand := func() bool {
-			switch command.(type) {
-			case commands.Cached:
-				return true
-			default:
-				return false
-			}
-		}()
-
 		if timing.TracingEnabled() {
-			phase := "kaniko"
-			switch command.(type) {
-			case *commands.RunCommand, *commands.RunMarkerCommand:
-				phase = "build"
-			}
 			attrs := []attribute.KeyValue{
 				attribute.String("kaniko.command", command.String()),
 				attribute.String("kaniko.command.hash", commandHash(s.index, command.String())),
-				attribute.String("kaniko.phase", phase),
 				attribute.Int("kaniko.instruction.index", index),
 				attribute.Int("kaniko.instruction.line", s.lines[index]),
 				attribute.Int("kaniko.stage", s.index),
@@ -700,21 +689,11 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 			cmdTimer.SetAttributes(attrs...)
 		}
 
-		if !initSnapshotTaken && !isCacheCommand && !command.ProvidesFilesToSnapshot() {
-			// Take initial snapshot if command does not expect to return
-			// a list of files.
-			// Stage setup, taken once for whichever command first needs it, so it
-			// belongs to the stage rather than to that arbitrary command.
-			t := timing.StartChild(s.span, "Initial FS snapshot")
-			err := snapshotter.Init()
-			t.End()
-			if err != nil {
-				return err
-			}
-			initSnapshotTaken = true
-		}
-
 		execTimer := timing.Start("Execute")
+		switch command.(type) {
+		case *commands.RunCommand, *commands.RunMarkerCommand:
+			execTimer.SetAttributes(attribute.String("kaniko.phase", "build"))
+		}
 		err := command.ExecuteCommand(&s.cf.Config, s.args)
 		execTimer.End()
 		if err != nil {
@@ -796,11 +775,8 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 			}
 		}
 	}
-
-	// The stage waits for the uploads its commands kicked off, so close the last
-	// command first: the wait is the stage's, not that command's. It needs no span
-	// of its own, the layer pushes already cover the window it blocks on.
 	endCmd()
+
 	if err := cacheGroup.Wait(); err != nil {
 		logrus.Warnf("Error uploading layer to cache: %s", err)
 	}
@@ -1291,8 +1267,6 @@ func RenderStages(stages []config.KanikoStage, cacheInfo []*stageCacheInfo, opts
 
 // DoBuild executes building the Dockerfile
 func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
-	t := timing.Start("Total Build Time")
-	defer t.End()
 	stageFinalCacheKeys := make(map[int]string)
 
 	stages, metaArgs, err := dockerfile.ParseStages(opts)
@@ -1511,24 +1485,10 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		}
 	}
 
-	// One span per stage, so fetching its base, unpacking it and every command it
-	// runs hang off the stage they belong to. Same close-on-next-iteration shape
-	// as the command spans, which covers the error returns below. Deferred before
-	// the cleanup below so LIFO order closes the final stage only after the
-	// filesystem cleanup has run inside its span.
-	var stageSpan trace.Span
-	var stageScope func()
-	endStage := func() {
-		if stageScope != nil {
-			stageScope()
-			stageScope = nil
-		}
-		if stageSpan != nil {
-			stageSpan.End()
-			stageSpan = nil
-		}
-	}
-	defer endStage()
+	// Deferred before the cleanup below so LIFO order closes the final stage
+	// only after the filesystem cleanup has run inside its span.
+	endStage := func() {}
+	defer func() { endStage() }()
 
 	if opts.Cleanup {
 		defer assignIfNil(&retErr, func() error {
@@ -1552,12 +1512,12 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	var pushImage v1.Image
 	for _, stage := range kanikoStages {
 		endStage()
-		stageSpan = timing.Start("Stage")
+		stageSpan, closeStage := timing.Scope("Stage")
 		stageSpan.SetAttributes(
 			attribute.Int("kaniko.stage", stage.Index),
 			attribute.String("kaniko.stage.name", stage.Name),
 		)
-		stageScope = timing.Scope(stageSpan)
+		endStage = closeStage
 
 		baseImage, err := retrieveBaseImage(stage, opts, sharedRemote[stage.BaseImageDigest])
 		if err != nil {

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/osscontainertools/kaniko/pkg/dockerfile"
 	"github.com/osscontainertools/kaniko/pkg/util"
 	"github.com/osscontainertools/kaniko/testutil"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func Test_reviewConfig(t *testing.T) {
@@ -1462,7 +1463,7 @@ RUN foobar
 			}
 			originalPushCache := pushCache
 			defer func() { pushCache = originalPushCache }()
-			pushCache = func(_ *config.KanikoOptions, cacheKey, _, _ string) error {
+			pushCache = func(_ *config.KanikoOptions, cacheKey, _, _ string, _ trace.Span) error {
 				keys = append(keys, cacheKey)
 				return nil
 			}

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -195,9 +195,6 @@ func writeDigestFile(path string, digestByteArray []byte) error {
 // DoPush is responsible for pushing image to the destinations specified in opts.
 // A dummy destination would be set when --no-push is set to true and --tar-path
 // is not empty with empty --destinations.
-// The push phase roll-up belongs to the caller pushing the built image. Cache
-// layers and pointers come through here too, and they already have their own
-// spans, so timing them as a whole push phase reported one per cache entry.
 func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 	assert.Assert("executor.push.image-nonnull", image != nil, "DoPush called with nil image")
 

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -48,6 +48,7 @@ import (
 	"github.com/osscontainertools/kaniko/pkg/version"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type withUserAgent struct {
@@ -194,11 +195,11 @@ func writeDigestFile(path string, digestByteArray []byte) error {
 // DoPush is responsible for pushing image to the destinations specified in opts.
 // A dummy destination would be set when --no-push is set to true and --tar-path
 // is not empty with empty --destinations.
+// The push phase roll-up belongs to the caller pushing the built image. Cache
+// layers and pointers come through here too, and they already have their own
+// spans, so timing them as a whole push phase reported one per cache entry.
 func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 	assert.Assert("executor.push.image-nonnull", image != nil, "DoPush called with nil image")
-
-	t := timing.Start("Total Push Time")
-	defer t.End()
 
 	var digestByteArray []byte
 	var builder strings.Builder
@@ -390,8 +391,8 @@ func writeImageOutputs(image v1.Image, destRefs []name.Tag) error {
 
 // pushLayerToCache pushes layer (tagged with cacheKey) to opts.CacheRepo
 // if opts.CacheRepo doesn't exist, infer the cache from the given destination
-func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath string, createdBy string) error {
-	t := timing.Start("Pushing cached layer")
+func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath string, createdBy string, parent trace.Span) error {
+	t := timing.StartChild(parent, "Pushing cached layer")
 	defer t.End()
 	var layerOpts []tarball.LayerOption
 	if opts.CompressedCaching {
@@ -456,8 +457,8 @@ const cachePointerLabel = "kaniko.cache.pointer-target"
 // pushCachePointer pushes a lightweight pointer entry under inferredKey that records
 // the content-addressed contentKey. On a subsequent build, resolving the pointer via
 // resolveCachePointer gives the contentKey so the cache chain can be continued correctly.
-func pushCachePointer(opts *config.KanikoOptions, inferredKey, contentKey string) error {
-	t := timing.Start("Pushing cache pointer")
+func pushCachePointer(opts *config.KanikoOptions, inferredKey, contentKey string, parent trace.Span) error {
+	t := timing.StartChild(parent, "Pushing cache pointer")
 	defer t.End()
 	dest, err := cache.Destination(opts, inferredKey)
 	if err != nil {

--- a/pkg/timing/timing.go
+++ b/pkg/timing/timing.go
@@ -29,7 +29,29 @@ var (
 	tracerMu  sync.Mutex
 	tracer    trace.Tracer
 	parentCtx context.Context
+	// scopes is the stack of spans an operation belongs to, innermost last. A
+	// stage pushes its span, each command pushes its own, so a span started
+	// anywhere in the call tree below them lands under the right one without
+	// every function in between having to carry a parent.
+	scopes []trace.Span
 )
+
+// Scope makes span the parent of spans started until the returned function runs.
+// Only the sequential build path may use it, work handed to a goroutine has to
+// name its parent with StartChild instead.
+func Scope(span trace.Span) func() {
+	tracerMu.Lock()
+	scopes = append(scopes, span)
+	depth := len(scopes)
+	tracerMu.Unlock()
+	return func() {
+		tracerMu.Lock()
+		defer tracerMu.Unlock()
+		if len(scopes) >= depth {
+			scopes = scopes[:depth-1]
+		}
+	}
+}
 
 func SetTracer(ctx context.Context, t trace.Tracer) {
 	tracerMu.Lock()
@@ -55,6 +77,7 @@ var noSpanCategories = map[string]bool{
 var networkCategories = map[string]bool{
 	"Retrieving Source Image": true,
 	"Fetching Extra Stages":   true,
+	"Downloading base image":  true,
 	"Pushing cached layer":    true,
 	"Pushing cache pointer":   true,
 	"Total Push Time":         true,
@@ -80,6 +103,9 @@ func StartChild(parent trace.Span, category string) trace.Span {
 func start(parent trace.Span, category string) trace.Span {
 	tracerMu.Lock()
 	tr, ctx := tracer, parentCtx
+	if parent == nil && len(scopes) > 0 {
+		parent = scopes[len(scopes)-1]
+	}
 	tracerMu.Unlock()
 	if tr == nil || noSpanCategories[category] {
 		return noop.Span{}

--- a/pkg/timing/timing.go
+++ b/pkg/timing/timing.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/osscontainertools/kaniko/pkg/assert"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
@@ -28,28 +29,32 @@ import (
 var (
 	tracerMu  sync.Mutex
 	tracer    trace.Tracer
-	parentCtx context.Context
-	// scopes is the stack of spans an operation belongs to, innermost last. A
-	// stage pushes its span, each command pushes its own, so a span started
-	// anywhere in the call tree below them lands under the right one without
-	// every function in between having to carry a parent.
-	scopes []trace.Span
+	parentCtx = context.Background()
 )
 
-// Scope makes span the parent of spans started until the returned function runs.
-// Only the sequential build path may use it, work handed to a goroutine has to
-// name its parent with StartChild instead.
-func Scope(span trace.Span) func() {
+// Scope begins a span for category and makes it the parent of spans started until
+// the returned function runs, which also ends the span. Only the sequential build
+// path may use it, work handed to a goroutine has to name its parent with
+// StartChild instead.
+func Scope(category string) (trace.Span, func()) {
+	assert.Assert("timing.scope.container", containerCategories[category], "timing.Scope: %v is not a container category", category)
+	span := start(nil, category)
+	id := span.SpanContext().SpanID()
 	tracerMu.Lock()
-	scopes = append(scopes, span)
-	depth := len(scopes)
+	prev := parentCtx
+	parentCtx = trace.ContextWithSpan(parentCtx, span)
 	tracerMu.Unlock()
-	return func() {
+	closed := false
+	return span, func() {
 		tracerMu.Lock()
-		defer tracerMu.Unlock()
-		if len(scopes) >= depth {
-			scopes = scopes[:depth-1]
+		innermost, first := trace.SpanFromContext(parentCtx).SpanContext().SpanID(), !closed
+		if first {
+			parentCtx = prev
+			closed = true
 		}
+		tracerMu.Unlock()
+		assert.Assert("timing.scope.nesting", !first || innermost == id, "timing.Scope: innermost scope is not the span being closed")
+		span.End()
 	}
 }
 
@@ -83,7 +88,16 @@ var networkCategories = map[string]bool{
 	"Total Push Time":         true,
 }
 
+var containerCategories = map[string]bool{
+	"Stage":            true,
+	"Command":          true,
+	"Total Build Time": true,
+}
+
 func phaseFor(category string) string {
+	if containerCategories[category] {
+		return ""
+	}
 	if networkCategories[category] {
 		return "network"
 	}
@@ -103,9 +117,6 @@ func StartChild(parent trace.Span, category string) trace.Span {
 func start(parent trace.Span, category string) trace.Span {
 	tracerMu.Lock()
 	tr, ctx := tracer, parentCtx
-	if parent == nil && len(scopes) > 0 {
-		parent = scopes[len(scopes)-1]
-	}
 	tracerMu.Unlock()
 	if tr == nil || noSpanCategories[category] {
 		return noop.Span{}
@@ -114,6 +125,9 @@ func start(parent trace.Span, category string) trace.Span {
 		ctx = trace.ContextWithSpan(ctx, parent)
 	}
 	_, span := tr.Start(ctx, category)
-	span.SetAttributes(attribute.String("kaniko.phase", phaseFor(category)))
+	phase := phaseFor(category)
+	if phase != "" {
+		span.SetAttributes(attribute.String("kaniko.phase", phase))
+	}
 	return span
 }

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -252,6 +252,8 @@ func extractLayer(i int, l v1.Layer, root string, cfg *FSConfig) ([]string, erro
 
 // DeleteFilesystem deletes the extracted image file system
 func DeleteFilesystem() error {
+	t := timing.Start("FS Cleaning")
+	defer t.End()
 	logrus.Info("Deleting filesystem...")
 	return fs.WalkDir(FSys, config.RootDir, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {


### PR DESCRIPTION
Every operation now hangs off the stage or the command it belongs to, instead of being a flat list of siblings under the root.

```
build
├── Resolving Extra Stage Digests / Fetching Extra Stages / FS Cleaning
├── Stage                          kaniko.stage, kaniko.stage.name
│   ├── Retrieving Source Image / FS Unpacking / Initial FS snapshot / Saving stage
│   ├── Pushing cached layer       (async, parented explicitly)
│   └── Command                    kaniko.command, line, stage
│       ├── Execute
│       └── Snapshotting FS
└── Total Push Time                (the image push only)
```

`timing.Scope` does the work: a stage pushes its span, each command pushes its own, and `timing.Start` picks up the innermost. The six functions that start spans, several of them free functions in other packages, need no parent parameter. Only work handed to a goroutine names its parent explicitly with `StartChild`, because the scope stack is not safe to read from another goroutine.

Also in here:

- `Downloading base image` was missing from `networkCategories`, so a registry pull plus disk write reported as processing. Plain bug.
- `Total Push Time` moves from `DoPush` to the image-push call site. `pushLayerToCache` and `pushCachePointer` also go through `DoPush`, so a cached build emitted one push roll-up per cache entry, each nested inside `Pushing cached layer`. That is what made a six-stage build look like it had six push phases.
- `Initial FS snapshot` is stage setup, taken once for whichever command first needs it, so it moves from that arbitrary command to the stage. It was making one instruction look 78x dearer than its neighbours.
- `Command` stays open through its snapshot, so an instruction covers everything it caused, but it is closed before `cacheGroup.Wait()`: the wait is the stage's, not the last command's. On a six-stage build that stopped a trailing `LABEL` from reporting 100 ms of someone else's uploads, it now reports 2 ms. The wait gets no span of its own, it is not an action, and the layer pushes already cover the window it blocks on.
- `util.DeleteFilesystem` gets an `FS Cleaning` span.

`FS Unpacking` keeps reporting `kaniko`. Extraction pulls the layers off the registry when nothing has them locally, so it is transfer and processing interleaved and a fixed label has to misreport one of them. Measuring the time blocked reading layers and attributing only that to networking is the right fix and is not in this PR.

Verified end to end against a collector and ClickHouse with a six-stage Dockerfile (cross-stage `COPY --from`, an external stage, cache on), cold and warm. The tree above is what the exported trace actually contains. `go build ./...` clean, `pkg/timing`, `pkg/tracing` and `pkg/executor` tests pass. The 4 failures in `pkg/util` are pre-existing on main and unchanged by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed build telemetry with nested spans for builds, stages, commands, execution, cache operations, image pushing, and filesystem cleanup.
  * Added stage indexes and names to build traces.
  * Improved timing coverage for build and push operations, including operations that return errors.
  * Clarified phase attribution across telemetry spans for more consistent observability.

* **Documentation**
  * Updated telemetry documentation to describe stage spans and revised phase attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->