### PR TITLE
mz1007: require the mount status on the access log line

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1780,8 +1780,8 @@ func TestCrossRepoMountFallback(t *testing.T) {
 			repo := strings.TrimPrefix(destination, "127.0.0.2:5001/")
 			mounted := false
 			for line := range strings.SplitSeq(registryLog(t), "\n") {
-				if strings.Contains(line, "/v2/"+repo+"/blobs/uploads/?") && strings.Contains(line, "mount=") {
-					mounted = strings.Contains(line, `HTTP/2.0" `+tc.mountReply)
+				if strings.Contains(line, "/v2/"+repo+"/blobs/uploads/?") && strings.Contains(line, "mount=") && strings.Contains(line, `HTTP/2.0" `+tc.mountReply) {
+					mounted = true
 				}
 			}
 			if !mounted {


### PR DESCRIPTION
TestCrossRepoMountFallback has been failing on main and on pull requests since it landed, about every other attempt. The mount itself is fine. The registry logs every request three times, as a structured "authorized request" line, as the combined access log line, and as a structured "response completed" line, and all three carry the request URI. The test kept the last line that mentioned the upload URI with a mount parameter and then asked that line for the status, so whenever the registry happened to write "response completed" after the access log line the verdict was taken from a line that has no status in it. Asking for the status on the same line that has to match the URI takes the ordering out of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved registry mount log validation to ensure it matches the correct upload request, expected HTTP status, and mount query.
  - Prevented unrelated registry log entries from producing false-positive test results.
  - Increased confidence that integration tests verify the intended registry operation rather than merely matching similar log output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->