### PR TITLE
tracing: record the build plan on the trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1486,7 +1486,7 @@ KANIKO_TELEMETRY_ENDPOINT=http://otel-collector:4318
 
 Each build becomes a trace, with a span per build phase and Dockerfile command. Telemetry is best effort and never fails a build.
 
-**What leaves the machine**: every trace carries the full Dockerfile source (`kaniko.dockerfile.content`), the verbatim text of every instruction, the values of any explicitly-set `FF_KANIKO_*` flags, and cache keys, all unredacted. Nothing beyond that is captured: the runtime value behind a `RUN --mount=type=secret` or the contents of a `--mount=type=cache` never reach a trace. In case your Dockerfile and `RUN` themselves contain credentials, treat the collector as part of your secret boundary.
+**What leaves the machine**: every trace carries the verbatim text of every instruction, the values of any explicitly-set `FF_KANIKO_*` flags, and cache keys, all unredacted, plus the full Dockerfile source (`kaniko.dockerfile.content`) and the build plan (`kaniko.plan`) unless `KANIKO_TELEMETRY_OMIT_DOCKERFILE=true`. Nothing beyond that is captured: the runtime value behind a `RUN --mount=type=secret` or the contents of a `--mount=type=cache` never reach a trace. In case your Dockerfile and `RUN` themselves contain credentials, treat the collector as part of your secret boundary.
 
 Spans are sent over OTLP/**HTTP(S)**, OTLP/**gRPC** is not supported. The endpoint URL must include a scheme, and only `KANIKO_TELEMETRY_ENDPOINT` enables tracing, the standard `OTEL_EXPORTER_OTLP_ENDPOINT` alone does not.
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -21,6 +21,7 @@ Attribute values are capped at 64 KiB. `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` 
 | `kaniko.version` | kaniko version |
 | `kaniko.dockerfile` | Dockerfile path |
 | `kaniko.dockerfile.content` | full Dockerfile source (absent for URL Dockerfiles) |
+| `kaniko.plan` | build plan, the text `--dryrun` would print |
 | `kaniko.target` | build target(s), comma-joined |
 | `kaniko.build_id` | sha256 of Dockerfile content + target, for grouping runs of the same build (falls back to the path when the Dockerfile is unreadable) |
 | `kaniko.ff.*` | explicitly-set `FF_KANIKO_*` feature flags (flags left at their defaults are not reported) |

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -17,6 +17,7 @@ limitations under the License.
 package executor
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -55,6 +56,7 @@ import (
 	"github.com/osscontainertools/kaniko/pkg/mounts"
 	"github.com/osscontainertools/kaniko/pkg/snapshot"
 	"github.com/osscontainertools/kaniko/pkg/timing"
+	"github.com/osscontainertools/kaniko/pkg/tracing"
 	"github.com/osscontainertools/kaniko/pkg/util"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -1105,10 +1107,10 @@ type pushedLayer struct {
 	key  v1.Hash
 }
 
-func RenderStages(stages []config.KanikoStage, cacheInfo []*stageCacheInfo, opts *config.KanikoOptions, fileContext util.FileContext, crossStageDependencies map[int][]string, layerCache *memoizedLayerCache, externalImageDigests map[string]string, sharedRemote map[string]bool) (retErr error) {
+func RenderStages(w io.Writer, stages []config.KanikoStage, cacheInfo []*stageCacheInfo, opts *config.KanikoOptions, fileContext util.FileContext, crossStageDependencies map[int][]string, layerCache *memoizedLayerCache, externalImageDigests map[string]string, sharedRemote map[string]bool) (retErr error) {
 	printf := func(format string, args ...any) {
 		if retErr == nil {
-			_, retErr = fmt.Fprintf(Out, format, args...)
+			_, retErr = fmt.Fprintf(w, format, args...)
 		}
 	}
 
@@ -1451,10 +1453,22 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		kanikoStages = onlyUsedStages
 	}
 
+	tracePlan := os.Getenv(tracing.EndpointEnv) != "" && !config.EnvBool(tracing.OmitDockerfileEnv)
+	var plan bytes.Buffer
+	var sinks []io.Writer
 	if opts.Dryrun || config.EnvBool("KANIKO_PRINT_PLAN") {
-		err := RenderStages(kanikoStages, cacheInfo, opts, fileContext, crossStageDependencies, layerCache, externalImageDigests, sharedRemote)
+		sinks = append(sinks, Out)
+	}
+	if tracePlan {
+		sinks = append(sinks, &plan)
+	}
+	if len(sinks) > 0 {
+		err := RenderStages(io.MultiWriter(sinks...), kanikoStages, cacheInfo, opts, fileContext, crossStageDependencies, layerCache, externalImageDigests, sharedRemote)
 		if err != nil {
 			return nil, err
+		}
+		if tracePlan {
+			tracing.SetPlan(plan.String())
 		}
 		if opts.Dryrun {
 			return nil, nil

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -174,6 +174,14 @@ func registryAttrs(s connstats.Stats) []attribute.KeyValue {
 	}
 }
 
+func SetPlan(plan string) {
+	mu.Lock()
+	defer mu.Unlock()
+	if rootSpan != nil {
+		rootSpan.SetAttributes(attribute.String("kaniko.plan", plan))
+	}
+}
+
 // buildAttrs holds what kaniko knows; fleet identity comes from
 // OTEL_RESOURCE_ATTRIBUTES. build_id groups runs of the same Dockerfile+target.
 func buildAttrs(opts *config.KanikoOptions, dockerfile []byte) []attribute.KeyValue {


### PR DESCRIPTION
A trace shows what kaniko did, never what it decided. An eliminated stage appears only as an absence, and a squashed stage appears under the name of the stage it was folded into, so a reader has to reconstruct both from which Dockerfile lines happen to have spans. That reconstruction is guesswork, and it cannot recover why a stage went away or which base-image path was taken.

`--dryrun` already renders exactly that information. This records the same text on the root span as `kaniko.plan`, so the decision travels with the build:

```
FROM localhost:5000/busybox AS final
  STREAM localhost:5000/busybox
RUN touch /a
RUN touch /b
PUSH [localhost:5000/wf-test:plan]
  UPLOAD sha256:b0509380…
  UPLOAD RUN touch /a
```

That build's Dockerfile declares three stages. The plan states plainly that `unused` was eliminated, that `base` and `final` were squashed into one builder, and that the base was streamed rather than fetched and unpacked. None of it is inferable from the spans.

`RenderStages` now takes the writer it renders into. `--dryrun` and `KANIKO_PRINT_PLAN` still stream to stdout byte-for-byte what they printed before, teed into a buffer that tracing reads.

**Sensitivity.** The plan names the same images, commands and layer digests as the source it derives from, so it is gated on the existing `KANIKO_TELEMETRY_OMIT_DOCKERFILE` rather than on a flag of its own: anyone withholding the Dockerfile is withholding the plan for the same reason. Documented in `docs/telemetry.md` and in the README's "what leaves the machine" note.

Verified end to end against a collector and ClickHouse: the attribute lands on the root span with the text above. `pkg/executor` and `pkg/tracing` tests pass, and there is no import cycle from `pkg/executor` gaining `pkg/tracing`.

Stacked on nothing, so it can merge independently of #1019.
