### PR TITLE
keep the integration cache out of the build context

### DIFF
--- a/integration/.dockerignore
+++ b/integration/.dockerignore
@@ -1,3 +1,4 @@
 # A .dockerignore file to make sure dockerignore support works
 ignore/**
 !ignore/foo
+cache


### PR DESCRIPTION
The harness writes the OCI cache and the warmer cache into `/workspace/cache`, which sits inside the build context, so the tests that copy the whole context race with them.