### PR TITLE
strip debug symbols from the credential helper binaries

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -42,9 +42,9 @@ RUN mkdir -p /kaniko/.docker
 # The acr helper binary is named docker-credential-acr upstream, keep the old name so
 # existing credHelpers entries for "acr-env" keep resolving.
 COPY go.mod go.sum ./
-RUN go build -o out/ github.com/GoogleCloudPlatform/docker-credential-gcr/v2 \
-    && go build -o out/ github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login \
-    && go build -o out/docker-credential-acr-env github.com/osscontainertools/docker-credential-acr \
+RUN go build -ldflags "-w -s" -o out/ github.com/GoogleCloudPlatform/docker-credential-gcr/v2 \
+    && go build -ldflags "-w -s" -o out/ github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login \
+    && go build -ldflags "-w -s" -o out/docker-credential-acr-env github.com/osscontainertools/docker-credential-acr \
     && rm -rf /root/.cache /go/pkg
 
 COPY . .


### PR DESCRIPTION
The executor and warmer are linked with `-w -s` through the Makefile, but the three credential helpers are built here with a bare `go build`, so they ship with their full DWARF and symbol tables. A quarter of the executor image is debug information for binaries nobody debugs.

Measured on the `kaniko-executor` target built for `linux/amd64` off `6bcc93443` and pushed to a registry, so these are the real compressed layer sizes rather than an estimate.

| layer | main | this PR |
| --- | ---: | ---: |
| docker-credential-gcr | 6.52 MB | 3.42 MB |
| docker-credential-ecr-login | 7.33 MB | 3.82 MB |
| docker-credential-acr-env | 5.69 MB | 3.04 MB |
| **image total** | **36.53 MB** | **27.26 MB** |

No other layer moves. 36.53 MB down to 27.26 MB, a 25.4% cut, from three flags. All three helpers still run and report their versions from the stripped build, and the flags now match what the Makefile already does for the two kaniko binaries.
