### PR TITLE
fix build_id for integration tests

### DIFF
--- a/integration/images.go
+++ b/integration/images.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/osscontainertools/kaniko/pkg/tracing"
 	"github.com/osscontainertools/kaniko/pkg/util"
 )
 
@@ -61,11 +62,11 @@ func addCoverageFlags(flags []string) []string {
 
 // addKanikoEnvFlags passes the suite's feature-flag matrix (KanikoEnv) to the executor
 // container. Every executor invocation must use it so all tests exercise the same flags.
-func addKanikoEnvFlags(flags []string) []string {
+func addKanikoEnvFlags(flags []string, buildID string) []string {
 	for _, envVariable := range KanikoEnv {
 		flags = append(flags, "-e", envVariable)
 	}
-	return flags
+	return append(flags, "-e", tracing.BuildIDEnv+"="+buildID)
 }
 
 // Arguments to build Dockerfiles with, used for both docker and kaniko builds
@@ -521,8 +522,6 @@ type DockerFileBuilder struct {
 	TestKanikoOnlyDockerfiles   map[string]struct{}
 }
 
-type logger func(string, ...any)
-
 // NewDockerFileBuilder will create a DockerFileBuilder initialized with dockerfiles, which
 // it will assume are all as yet unbuilt.
 func NewDockerFileBuilder() *DockerFileBuilder {
@@ -669,7 +668,7 @@ func (d *DockerFileBuilder) BuildKanikoImage(t *testing.T, config *integrationTe
 	additionalKanikoFlags = append(additionalKanikoFlags, "-c", buildContextPath)
 
 	kanikoImage := GetKanikoImage(config.imageRepo, dockerfile)
-	return buildKanikoImage(t.Logf, dockerfilesPath, dockerfile, buildArgs, additionalKanikoFlags, kanikoImage,
+	return buildKanikoImage(t, dockerfilesPath, dockerfile, buildArgs, additionalKanikoFlags, kanikoImage,
 		cwd, "", "")
 }
 
@@ -701,7 +700,7 @@ func (d *DockerFileBuilder) buildImage(t *testing.T, config *integrationTestConf
 	}
 
 	kanikoImage := GetKanikoImage(imageRepo, dockerfile)
-	if err := buildKanikoImage(t.Logf, dockerfilesPath, dockerfile, buildArgs, additionalKanikoFlags, kanikoImage,
+	if err := buildKanikoImage(t, dockerfilesPath, dockerfile, buildArgs, additionalKanikoFlags, kanikoImage,
 		contextDir, "", ""); err != nil {
 		return err
 	}
@@ -710,7 +709,7 @@ func (d *DockerFileBuilder) buildImage(t *testing.T, config *integrationTestConf
 }
 
 // buildCachedImage builds the image for testing caching via kaniko where version is the nth time this image has been built
-func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTestConfig, cacheRepo, dockerfilesPath, dockerfile string, version int, args []string) error {
+func (d *DockerFileBuilder) buildCachedImage(t *testing.T, config *integrationTestConfig, cacheRepo, dockerfilesPath, dockerfile string, version int, args []string) error {
 	imageRepo := config.imageRepo
 	_, ex, _, _ := runtime.Caller(0)
 	cwd := filepath.Dir(ex)
@@ -723,9 +722,7 @@ func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTes
 		"run", "--net=host",
 		"-v", cwd + ":/workspace",
 	}
-	for _, envVariable := range KanikoEnv {
-		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
-	}
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags, t.Name())
 	for _, envVariable := range envsMap[dockerfile] {
 		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
 	}
@@ -758,7 +755,7 @@ func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTes
 	kanikoCmd := exec.Command("docker", dockerRunFlags...)
 
 	out, err := RunCommandWithoutTest(kanikoCmd)
-	logf("%s", out)
+	t.Logf("%s", out)
 
 	if err != nil {
 		return fmt.Errorf("failed to build cached image %s with kaniko command \"%s\": %w", kanikoImage, kanikoCmd.Args, err)
@@ -786,16 +783,14 @@ func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTes
 	return nil
 }
 
-func (d *DockerFileBuilder) buildCachedImageInContext(logf logger, config *integrationTestConfig, cacheRepo, dockerfile, contextDir string, version int) error {
+func (d *DockerFileBuilder) buildCachedImageInContext(t *testing.T, config *integrationTestConfig, cacheRepo, dockerfile, contextDir string, version int) error {
 	_, ex, _, _ := runtime.Caller(0)
 	cwd := filepath.Dir(ex)
 
 	kanikoImage := GetVersionedKanikoImage(config.imageRepo, filepath.Base(contextDir), version)
 
 	dockerRunFlags := []string{"run", "--net=host", "-v", cwd + ":/workspace"}
-	for _, envVariable := range KanikoEnv {
-		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
-	}
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags, t.Name())
 	dockerRunFlags = addAuthFlags(dockerRunFlags)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
@@ -808,11 +803,11 @@ func (d *DockerFileBuilder) buildCachedImageInContext(logf logger, config *integ
 		"--cache-dir", cacheDir)
 
 	out, err := RunCommandWithoutTest(exec.Command("docker", dockerRunFlags...))
-	logf("%s", out)
+	t.Logf("%s", out)
 	return err
 }
 
-func populateVolumeCache(logf logger) error {
+func populateVolumeCache(t *testing.T) error {
 	fmt.Println("Populating warmer cache")
 	_, ex, _, _ := runtime.Caller(0)
 	cwd := filepath.Dir(ex)
@@ -833,7 +828,7 @@ func populateVolumeCache(logf logger) error {
 
 	warmerCmd := exec.Command("docker", cmd...)
 	out, err := RunCommandWithoutTest(warmerCmd)
-	logf("%s", out)
+	t.Logf("%s", out)
 	if err != nil {
 		return fmt.Errorf("failed to warm kaniko cache: %w", err)
 	}
@@ -841,7 +836,7 @@ func populateVolumeCache(logf logger) error {
 }
 
 // buildCachedImage builds the image for testing caching via kaniko warmer cache where version is the nth time this image has been built
-func (d *DockerFileBuilder) buildWarmerImage(logf logger, config *integrationTestConfig, dockerfilesPath, dockerfile string, version int, args []string, cache bool) error {
+func (d *DockerFileBuilder) buildWarmerImage(t *testing.T, config *integrationTestConfig, dockerfilesPath, dockerfile string, version int, args []string, cache bool) error {
 	imageRepo := config.imageRepo
 	_, ex, _, _ := runtime.Caller(0)
 	cwd := filepath.Dir(ex)
@@ -852,9 +847,7 @@ func (d *DockerFileBuilder) buildWarmerImage(logf logger, config *integrationTes
 		"run", "--net=host",
 		"-v", cwd + ":/workspace:ro",
 	}
-	for _, envVariable := range KanikoEnv {
-		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
-	}
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags, t.Name())
 	executorImage := ExecutorImage
 	if exec, ok := executorImages[dockerfile]; ok {
 		executorImage = exec
@@ -874,7 +867,7 @@ func (d *DockerFileBuilder) buildWarmerImage(logf logger, config *integrationTes
 	kanikoCmd := exec.Command("docker", dockerRunFlags...)
 
 	out, err := RunCommandWithoutTest(kanikoCmd)
-	logf("%s", out)
+	t.Logf("%s", out)
 
 	if err != nil {
 		return fmt.Errorf("failed to build image %s with kaniko command \"%s\": %w", kanikoImage, kanikoCmd.Args, err)
@@ -898,7 +891,7 @@ func (d *DockerFileBuilder) buildWarmerImage(logf logger, config *integrationTes
 }
 
 // buildRelativePathsImage builds the images for testing passing relatives paths to Kaniko
-func (d *DockerFileBuilder) buildRelativePathsImage(logf logger, imageRepo, dockerfile, buildContextPath string) error {
+func (d *DockerFileBuilder) buildRelativePathsImage(t *testing.T, imageRepo, dockerfile, buildContextPath string) error {
 	_, ex, _, _ := runtime.Caller(0)
 	cwd := filepath.Dir(ex)
 
@@ -921,9 +914,7 @@ func (d *DockerFileBuilder) buildRelativePathsImage(logf logger, imageRepo, dock
 	}
 
 	dockerRunFlags := []string{"run", "--net=host", "-v", cwd + ":/workspace"}
-	for _, envVariable := range KanikoEnv {
-		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
-	}
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags, t.Name())
 	executorImage := ExecutorImage
 	if exec, ok := executorImages[dockerfile]; ok {
 		executorImage = exec
@@ -938,7 +929,7 @@ func (d *DockerFileBuilder) buildRelativePathsImage(logf logger, imageRepo, dock
 	kanikoCmd := exec.Command("docker", dockerRunFlags...)
 
 	out, err = RunCommandWithoutTest(kanikoCmd)
-	logf("%s", out)
+	t.Logf("%s", out)
 
 	if err != nil {
 		return fmt.Errorf(
@@ -968,7 +959,7 @@ var extraDockerRunFlags = map[string]func(contextDir string) []string{
 }
 
 func buildKanikoImage(
-	logf logger,
+	t *testing.T,
 	dockerfilesPath string,
 	dockerfile string,
 	buildArgs []string,
@@ -985,16 +976,14 @@ func buildKanikoImage(
 		"--image-name-with-digest-file=/dev/stdout",
 		"--image-name-tag-with-digest-file=/dev/stdout",
 	)
-	logf("Going to build image with kaniko: %s, flags: %s \n", kanikoImage, additionalFlags)
+	t.Logf("Going to build image with kaniko: %s, flags: %s \n", kanikoImage, additionalFlags)
 
 	dockerRunFlags := []string{
 		"run", "--net=host",
 		"-v", contextDir + ":/workspace:ro",
 	}
 
-	for _, envVariable := range KanikoEnv {
-		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
-	}
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags, t.Name())
 	if env, ok := envsMap[dockerfile]; ok {
 		for _, envVariable := range env {
 			dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
@@ -1036,7 +1025,7 @@ func buildKanikoImage(
 	kanikoCmd := exec.Command("docker", dockerRunFlags...)
 
 	out, err := RunCommandWithoutTest(kanikoCmd)
-	logf("%s", out)
+	t.Logf("%s", out)
 
 	if err != nil {
 		return fmt.Errorf("failed to build image %s with kaniko command \"%s\": %w", kanikoImage, kanikoCmd.Args, err)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -357,7 +357,7 @@ func testGitBuildcontextHelper(t *testing.T, url string, commit string, branch s
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addAuthFlags(dockerRunFlags)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags, t.Name())
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -429,7 +429,7 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addAuthFlags(dockerRunFlags)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags, t.Name())
 	dockerRunFlags = append(
 		dockerRunFlags,
 		ExecutorImage,
@@ -474,7 +474,7 @@ func TestBuildViaRegistryMirrors(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addAuthFlags(dockerRunFlags)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags, t.Name())
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -517,7 +517,7 @@ func TestBuildViaRegistryMap(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addAuthFlags(dockerRunFlags)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags, t.Name())
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -545,7 +545,7 @@ func TestBuildSkipFallback(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addAuthFlags(dockerRunFlags)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags, t.Name())
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -587,7 +587,7 @@ func TestKanikoDir(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addAuthFlags(dockerRunFlags)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags, t.Name())
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -632,7 +632,7 @@ func TestBuildWithLabels(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addAuthFlags(dockerRunFlags)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags, t.Name())
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -674,7 +674,7 @@ func TestBuildWithHTTPError(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addAuthFlags(dockerRunFlags)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags, t.Name())
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -953,7 +953,7 @@ func TestSnapshotModes(t *testing.T) {
 		t.Helper()
 		tag := GetKanikoImage(config.imageRepo, dockerfile+"-snapshot-"+mode)
 		kanikoArgs := []string{"-c", buildContextPath, "--snapshot-mode=" + mode}
-		if err := buildKanikoImage(t.Logf, dockerfilesPath, dockerfile, buildArgs, kanikoArgs, tag, cwd, "", ""); err != nil {
+		if err := buildKanikoImage(t, dockerfilesPath, dockerfile, buildArgs, kanikoArgs, tag, cwd, "", ""); err != nil {
 			t.Fatalf("kaniko build with --snapshot-mode=%s: %v", mode, err)
 		}
 		return tag
@@ -994,7 +994,7 @@ func TestReproducible(t *testing.T) {
 		buildArgs = append(buildArgs, "--build-arg", "IMAGE_REPO="+config.imageRepo)
 		flags := []string{"-c", buildContextPath, "--reproducible"}
 		flags = append(flags, additionalKanikoFlagsMap[dockerfile]...)
-		err := buildKanikoImage(t.Logf, dockerfilesPath, dockerfile, buildArgs, flags, ref,
+		err := buildKanikoImage(t, dockerfilesPath, dockerfile, buildArgs, flags, ref,
 			cwd, "", "")
 		if err != nil {
 			t.Fatalf("build %s -> %s: %v", dockerfile, ref, err)
@@ -1057,7 +1057,7 @@ func TestCache(t *testing.T) {
 
 func TestWarmer(t *testing.T) {
 	t.Parallel()
-	populateVolumeCache(t.Logf)
+	populateVolumeCache(t)
 
 	for dockerfile := range imageBuilder.TestWarmerDockerfiles {
 		t.Run("test_warmer_"+dockerfile, func(t *testing.T) {
@@ -1069,12 +1069,12 @@ func TestWarmer(t *testing.T) {
 			}
 
 			// Build the initial without warmer
-			if err := imageBuilder.buildWarmerImage(t.Logf, config, dockerfilesPath, dockerfile, 0, args, false); err != nil {
+			if err := imageBuilder.buildWarmerImage(t, config, dockerfilesPath, dockerfile, 0, args, false); err != nil {
 				t.Fatalf("error building cached image for the first time: %v", err)
 			}
 
 			// Build the second with warmer
-			if err := imageBuilder.buildWarmerImage(t.Logf, config, dockerfilesPath, dockerfile, 1, args, true); err != nil {
+			if err := imageBuilder.buildWarmerImage(t, config, dockerfilesPath, dockerfile, 1, args, true); err != nil {
 				t.Fatalf("error building cached image for the second time: %v", err)
 			}
 
@@ -1155,11 +1155,11 @@ func verifyBuildWith(t *testing.T, cache, dockerfile string) {
 	}
 
 	// Build the initial image which will cache layers
-	if err := imageBuilder.buildCachedImage(t.Logf, config, cache, dockerfilesPath, dockerfile, 0, args); err != nil {
+	if err := imageBuilder.buildCachedImage(t, config, cache, dockerfilesPath, dockerfile, 0, args); err != nil {
 		t.Fatalf("error building cached image for the first time: %v", err)
 	}
 	// Build the second image which should pull from the cache
-	if err := imageBuilder.buildCachedImage(t.Logf, config, cache, dockerfilesPath, dockerfile, 1, args); err != nil {
+	if err := imageBuilder.buildCachedImage(t, config, cache, dockerfilesPath, dockerfile, 1, args); err != nil {
 		t.Fatalf("error building cached image for the second time: %v", err)
 	}
 	// Make sure both images are the same
@@ -1184,11 +1184,11 @@ func TestCacheInvalidatesOnAllowlistedFileChange(t *testing.T) {
 
 	const dockerfile = "testdata/test_issue_mz762/Dockerfile"
 
-	if err := imageBuilder.buildCachedImageInContext(t.Logf, config, cacheRepo, dockerfile, "testdata/test_issue_mz762/original", 0); err != nil {
+	if err := imageBuilder.buildCachedImageInContext(t, config, cacheRepo, dockerfile, "testdata/test_issue_mz762/original", 0); err != nil {
 		t.Fatalf("error building original image: %v", err)
 	}
 
-	if err := imageBuilder.buildCachedImageInContext(t.Logf, config, cacheRepo, dockerfile, "testdata/test_issue_mz762/changed", 0); err != nil {
+	if err := imageBuilder.buildCachedImageInContext(t, config, cacheRepo, dockerfile, "testdata/test_issue_mz762/changed", 0); err != nil {
 		t.Fatalf("error building changed image: %v", err)
 	}
 
@@ -1255,7 +1255,7 @@ func TestRelativePaths(t *testing.T) {
 		contextPath := "./context"
 
 		err := imageBuilder.buildRelativePathsImage(
-			t.Logf,
+			t,
 			config.imageRepo,
 			dockerfile,
 			contextPath,
@@ -1319,7 +1319,7 @@ func TestExitCodePropagation(t *testing.T) {
 		}
 		dockerFlags = addAuthFlags(dockerFlags)
 		dockerFlags = addCoverageFlags(dockerFlags)
-		dockerFlags = addKanikoEnvFlags(dockerFlags)
+		dockerFlags = addKanikoEnvFlags(dockerFlags, t.Name())
 		dockerFlags = append(dockerFlags, ExecutorImage,
 			"-c", "dir:///workspace/",
 			"-f", "./Dockerfile_exit_code_propagation",
@@ -1373,7 +1373,7 @@ func TestBuildWithAnnotations(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addAuthFlags(dockerRunFlags)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags)
+	dockerRunFlags = addKanikoEnvFlags(dockerRunFlags, t.Name())
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -1411,7 +1411,7 @@ func TestPushFromArtifact(t *testing.T) {
 			runExecutor := func(executorArgs ...string) {
 				t.Helper()
 				flags := []string{"run", "--rm", "--net=host", "-v", outFlag + ":/out"}
-				flags = addKanikoEnvFlags(flags)
+				flags = addKanikoEnvFlags(flags, t.Name())
 				// mz731 keeps OCI base layers verbatim on the direct push, but the
 				// docker-archive --tar-path writer rewrites them to docker mediatypes, so
 				// the push-from-artifact image would not match. Disable it (after the
@@ -1668,7 +1668,7 @@ func TestAlpineTLS(t *testing.T) {
 	cwd := filepath.Dir(ex)
 	dest := "127.0.0.2:5001/kaniko/mz595-tls:latest"
 	err = buildKanikoImage(
-		t.Logf,
+		t,
 		dockerfilesPath,
 		"Dockerfile_test_issue_mz595",
 		nil,
@@ -1728,7 +1728,7 @@ func TestPushRepositoryScopedAuth(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := buildKanikoImage(
-				t.Logf,
+				t,
 				dockerfilesPath,
 				"Dockerfile_test_label",
 				nil,
@@ -1774,7 +1774,7 @@ func TestCrossRepoMountFallback(t *testing.T) {
 		"127.0.0.2:5001/userb/test_issue_mz1007": {Username: "userb", Password: "userb"},
 	})
 	err := buildKanikoImage(
-		t.Logf,
+		t,
 		dockerfilesPath,
 		"Dockerfile_test_label",
 		nil,
@@ -1813,7 +1813,7 @@ func TestCrossRepoMountFallback(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			destination := fmt.Sprintf("127.0.0.2:5001/usera/test_issue_mz1007-%s-%d", tc.repo, time.Now().UnixNano())
 			err = buildKanikoImage(
-				t.Logf,
+				t,
 				dockerfilesPath,
 				"Dockerfile_test_issue_mz1007",
 				[]string{"--build-arg", "BASE=" + base},
@@ -1987,7 +1987,7 @@ func TestCustomPlatformVariant(t *testing.T) {
 	cwd := filepath.Dir(ex)
 	kanikoImage := GetKanikoImage(config.imageRepo, "issue_mz745")
 	err := buildKanikoImage(
-		t.Logf,
+		t,
 		dockerfilesPath,
 		"Dockerfile_test_cross_compile",
 		nil,

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -55,6 +55,8 @@ var (
 // enables tracing when set to an OTLP-HTTP collector URL.
 const EndpointEnv = "KANIKO_TELEMETRY_ENDPOINT"
 
+const BuildIDEnv = "KANIKO_TELEMETRY_BUILD_ID"
+
 // whether to keep the Dockerfile source out of the trace.
 const OmitDockerfileEnv = "KANIKO_TELEMETRY_OMIT_DOCKERFILE"
 
@@ -209,6 +211,10 @@ func buildAttrs(opts *config.KanikoOptions, dockerfile []byte) []attribute.KeyVa
 // when the Dockerfile is readable; the path fallback is near-constant across
 // a fleet (everything mounts /workspace/Dockerfile), hence the preference.
 func buildID(path, target string, content []byte) string {
+	if id := os.Getenv(BuildIDEnv); id != "" {
+		return id
+	}
+
 	src := path
 	if content != nil {
 		src = string(content)


### PR DESCRIPTION
## Problem

`kaniko.build_id` is `sha256(dockerfileContent | target)[:16]`, so a job that
builds more than one image reports the same identity for all of them once the
Dockerfiles are similar, and editing a Dockerfile starts a new identity — which
splits a build's history exactly when you want to compare across the change.

kaniko cannot fix this by itself: which invocations are "the same logical build"
is something only the project knows.

## Change

`KANIKO_TELEMETRY_BUILD_ID` replaces the derived id when set. Everything else is
unchanged, so builds that do not set it behave exactly as before.

The integration suite is the case that needs it — one job, many images — so it
passes the variable per invocation. Four executor paths were expanding `KanikoEnv`
inline rather than going through the helper, and would have missed it (and any
future addition to the passthrough list); they now use the helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for setting a custom telemetry build ID through an environment variable.
  * Test execution now includes each test’s tracing build ID in Kaniko environments.

* **Bug Fixes**
  * Improved platform-aware caching to prevent foreign-architecture builds from reusing incompatible cache layers while preserving same-architecture reuse.

* **Refactor**
  * Streamlined integration-test logging and centralized environment configuration.

* **Tests**
  * Added coverage for platform-specific cache keys and updated related integration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->