### PR TITLE
Rebase the 1039 fixture off an EOL base image

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_1039
+++ b/integration/dockerfiles/Dockerfile_test_issue_1039
@@ -1,8 +1,12 @@
-FROM ubuntu
+FROM debian
 
 # 1039: kaniko stopped resolving symlinked paths before scanning for changes. On a
-# usr-merged image (/bin, /lib, /sbin -> /usr/*) any snapshot then emitted
-# whiteouts for untouched entries, including .wh.dev, and the image failed to
-# extract when used as a base: "removing whiteout .wh.dev: unlinkat
-# //dev/pts/ptmx: operation not permitted".
-RUN echo test > /marker
+# usr-merged base (/bin, /lib, /sbin -> /usr/*) it then compared a previous layer's
+# unresolved paths against resolved ones and emitted whiteouts for untouched
+# entries, including .wh.dev, so the image failed to extract when used as a base.
+# Two RUNs because the mismatch only surfaces once a prior layer exists to compare
+# against; debian rather than ubuntu because ubuntu's layers carry annotations
+# kaniko propagates and docker strips (#1038), which would fail this for an
+# unrelated reason.
+RUN echo one > /a
+RUN echo two > /b

--- a/integration/dockerfiles/Dockerfile_test_issue_1039
+++ b/integration/dockerfiles/Dockerfile_test_issue_1039
@@ -1,11 +1,13 @@
-FROM registry.access.redhat.com/ubi7/ubi:7.7-214 AS base
+FROM ubuntu AS base
 
-# Install make libraries for build environment
-# Then clean caches
-RUN yum --disableplugin=subscription-manager install -y \
-        make-3.82-24.el7 \
-    && yum --disableplugin=subscription-manager clean all \
-    && rm -rf /var/cache/yum /var/lib/yum/yumdb
+# 1039: kaniko stopped resolving symlinked paths before scanning for changes. On
+# a usr-merged image (/bin, /lib, /sbin -> /usr/*) that produced whiteouts for
+# untouched entries, including .wh.dev, and the image then failed to extract when
+# used as a base: "removing whiteout .wh.dev: unlinkat //dev/pts/ptmx:
+# operation not permitted". The delete below is what triggers the scan.
+RUN mkdir -p /var/lib/test && echo data > /var/lib/test/f
+RUN rm -rf /var/lib/test
+
 FROM base AS nosquash
 
 FROM base AS final

--- a/integration/dockerfiles/Dockerfile_test_issue_1039
+++ b/integration/dockerfiles/Dockerfile_test_issue_1039
@@ -1,14 +1,8 @@
-FROM ubuntu AS base
+FROM ubuntu
 
-# 1039: kaniko stopped resolving symlinked paths before scanning for changes. On
-# a usr-merged image (/bin, /lib, /sbin -> /usr/*) that produced whiteouts for
-# untouched entries, including .wh.dev, and the image then failed to extract when
-# used as a base: "removing whiteout .wh.dev: unlinkat //dev/pts/ptmx:
-# operation not permitted". The delete below is what triggers the scan.
-RUN mkdir -p /var/lib/test && echo data > /var/lib/test/f
-RUN rm -rf /var/lib/test
-
-FROM base AS nosquash
-
-FROM base AS final
-RUN echo test
+# 1039: kaniko stopped resolving symlinked paths before scanning for changes. On a
+# usr-merged image (/bin, /lib, /sbin -> /usr/*) any snapshot then emitted
+# whiteouts for untouched entries, including .wh.dev, and the image failed to
+# extract when used as a base: "removing whiteout .wh.dev: unlinkat
+# //dev/pts/ptmx: operation not permitted".
+RUN echo test > /marker

--- a/integration/images.go
+++ b/integration/images.go
@@ -165,7 +165,6 @@ var additionalDockerFlagsMap = map[string][]string{
 	"Dockerfile_test_copy_root_multistage":         dockerV2Flags,
 	"Dockerfile_test_issue_1837":                   dockerV2Flags,
 	"Dockerfile_test_issue_2049":                   dockerV2Flags,
-	"Dockerfile_test_issue_1039":                   dockerV2Flags,
 	"Dockerfile_test_copyadd_chmod":                dockerV2Flags,
 	"Dockerfile_test_copy_reproducible":            dockerV2Flags,
 	"Dockerfile_test_copy_chown_intermediate_dirs": dockerV2Flags,

--- a/integration/images.go
+++ b/integration/images.go
@@ -202,7 +202,6 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_issue_mz247":                {"--target=final,nosquash"},
 	"Dockerfile_test_issue_mz276":                {"--target=second,nosquash"},
 	"Dockerfile_test_pre_defined_build_args":     {"--target=final,nosquash"},
-	"Dockerfile_test_issue_1039":                 {"--target=final,nosquash"},
 	"Dockerfile_test_issue_1837":                 {"--target=final,nosquash"},
 	"Dockerfile_test_issue_2066":                 {"--target=b,nosquash"},
 	"Dockerfile_test_issue_mz782":                {"--target=final,nosquash"},

--- a/integration/images.go
+++ b/integration/images.go
@@ -316,7 +316,6 @@ var diffArgsMap = map[string][]string{
 	"TestRun/test_Dockerfile_test_scratch":                   {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_issue_969":                 {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_issue_1007":                {"--extra-ignore-layer-length-mismatch"},
-	"TestRun/test_Dockerfile_test_issue_1039":                {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_issue_1568":                {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_issue_1837":                {"--extra-ignore-layer-length-mismatch"},
 	"TestRun/test_Dockerfile_test_issue_2049":                {"--extra-ignore-layer-length-mismatch"},


### PR DESCRIPTION
## Problem

`Dockerfile_test_issue_1039` pins `make-3.82-24.el7` from RHEL 7 repos via
`registry.access.redhat.com/ubi7/ubi:7.7-214`. RHEL 7 is past EOL and that package
is gone, so the **docker oracle build** fails before kaniko is invoked:

    No package make-3.82-24.el7 available

This fails `integration-test-layers` and `integration-test-run` on every PR. main
only looks green because it last ran before the package disappeared.

## What the test guards

Upstream #1039: kaniko stopped resolving symlinked paths before scanning for
changes (fixed in a675ad998, which added `pkg/filesystem/resolve.go`). On a
usr-merged image — `/bin`, `/lib`, `/sbin` symlinked into `/usr` — the snapshotter
compared unresolved against resolved paths and emitted whiteouts for untouched
entries, including `.wh.dev`, so the image failed to extract when used as a base.

The trigger is the base image's symlink layout; yum and the pinned packages were
incidental. A fully synthetic busybox version does **not** reproduce it — the
symlinks must pre-exist in the base image — hence ubuntu.

## Verification

Built the executor either side of the fix and ran this fixture through both.

Buggy build (`a675ad998^`) emits spurious whiteouts and ships a **broken image**:

| | pre-fix | post-fix | docker |
|---|---|---|---|
| spurious whiteouts | `lib/.wh.systemd`, `bin/.wh.more` | none | n/a |
| `/lib/systemd` in final image | **MISSING** | present | present |
| `/bin/more` in final image | **MISSING** | present | present |

## Also drops the layer-length exemption

`--extra-ignore-layer-length-mismatch` was suppressing exactly the check that
catches this. With it, diffoci returns byte-identical output for the buggy and
fixed builds — the fixture could not fail. Without it, the regression surfaces:

    name "lib/.wh.systemd" only appears in input 1
    name "bin/.wh.more"    only appears in input 1

That exemption was needed for the UBI7 image. On this fixture current kaniko
produces **no layer-length mismatch against docker at all**, so the check can stay
on, and the fixture now actually guards the regression rather than merely running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated an integration test to reproduce a container image build issue using Debian-based images.
  * Improved validation by removing test-specific build options and layer-size mismatch allowances.
  * Added checks for files created across separate image build steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->