### PR TITLE
bump go to 1.26.7

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.6'
+          go-version: '1.26.7'
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.6'
+          go-version: '1.26.7'
 
       - run: make test
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BUILDPLATFORM
-FROM --platform=$BUILDPLATFORM golang:1.26.6@sha256:0d1d3a794be25f809dd2cb3160d8c73276c4056a9f8242a138e908ddeee7b6b6 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.7@sha256:dc2521c2a906db43073b8b4d99f491b6341cf15610b6ebbab187c45153f9959e AS builder
 WORKDIR /src
 
 # This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osscontainertools/kaniko
 
-go 1.26.6
+go 1.26.7
 
 require (
 	cloud.google.com/go/storage v1.65.0


### PR DESCRIPTION
Go 1.27 replaced the compress/flate encoder, so the same tar compresses to different bytes and every layer kaniko produces gets a new digest. That changes what image a build produces, which a patch release must not do, so #1034 has to wait for the next minor. 1.26.7 is byte identical to 1.26.6 on flate output and is the latest patch on the 1.26 line, so it keeps the toolchain current on security fixes in the meantime.