### PR TITLE
go-containerregistry learned to resolve at repository scope

### DIFF
--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
@@ -89,17 +88,6 @@ var (
 	checkRemotePushPermission = remote.CheckPushPermission
 )
 
-// remote.CheckPushPermission resolves at registry scope, which never matches a repository
-// entry. Answering every lookup with the repository credential works around that until the
-// vendored ggcr carries google/go-containerregistry#2411, then this goes away.
-type resolvedKeychain struct {
-	auth authn.Authenticator
-}
-
-func (k resolvedKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
-	return k.auth, nil
-}
-
 // CheckPushPermissions checks that the configured credentials can be used to
 // push to every specified destination.
 func CheckPushPermissions(opts *config.KanikoOptions) error {
@@ -142,11 +130,7 @@ func CheckPushPermissions(opts *config.KanikoOptions) error {
 			return fmt.Errorf("making transport for registry %q: %w", registryName, err)
 		}
 		tr := newRetry(rt)
-		pushAuth, err := creds.GetKeychain(&opts.RegistryOptions).Resolve(destRef.Context())
-		if err != nil {
-			return fmt.Errorf("resolving pushAuth: %w", err)
-		}
-		if err := checkRemotePushPermission(destRef, resolvedKeychain{auth: pushAuth}, tr); err != nil {
+		if err := checkRemotePushPermission(destRef, creds.GetKeychain(&opts.RegistryOptions), tr); err != nil {
 			return fmt.Errorf("checking push permission for %q: %w", destRef, err)
 		}
 		checked[destRef.Context().String()] = true


### PR DESCRIPTION
The vendored go-containerregistry is at 0.22.0, which carries google/go-containerregistry#2411, so `remote.CheckPushPermission` resolves the credential against the destination repository instead of the registry host. The adapter added in #1014 only existed to answer every registry-scoped lookup with the pre-resolved repository credential, so it can go and the keychain is handed in directly. `TestPushRepositoryScopedAuth` covers both cases it was protecting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push permission checks by using the configured authentication settings directly.
  * Removed an unnecessary authentication resolution step that could affect permission lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->