### PR TITLE
mz1048: drop repeatead syscalls in CopyDir

### DIFF
--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -142,7 +142,7 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 			continue
 		} else {
 			// ... Else, we want to copy over a file
-			exclude, err := util.CopyFile(fullPath, destPath, c.fileContext, uid, gid, chmod, useDefaultChmod, false)
+			exclude, err := util.CopyFile(fullPath, destPath, fi, c.fileContext, uid, gid, chmod, useDefaultChmod, false)
 			if err != nil {
 				return fmt.Errorf("copying file: %w", err)
 			}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -774,10 +774,10 @@ func CopyDir(src, dest string, context FileContext, uid, gid int64, chmod mode.S
 	if err != nil {
 		return nil, fmt.Errorf("copying dir: %w", err)
 	}
-	return copyDirInner(files, src, dest, context, uid, gid, chmod, useDefaultChmod, false)
+	return copyDirInner(files, src, dest, context, uid, gid, chmod, useDefaultChmod, false, true)
 }
 
-func copyDirInner(files []string, src, dest string, context FileContext, uid, gid int64, chmod mode.Set, useDefaultChmod bool, skipIgnoreList bool) ([]string, error) {
+func copyDirInner(files []string, src, dest string, context FileContext, uid, gid int64, chmod mode.Set, useDefaultChmod bool, skipIgnoreList bool, collect bool) ([]string, error) {
 	var copiedFiles []string
 	var updates []timestampUpdate
 	hardlinksSeen := make(map[uint64]string)
@@ -873,7 +873,9 @@ func copyDirInner(files []string, src, dest string, context FileContext, uid, gi
 		if fi.IsDir() || fi.Mode()&os.ModeNamedPipe != 0 {
 			updates = append(updates, timestampUpdate{fi: fi, dest: destPath})
 		}
-		copiedFiles = append(copiedFiles, destPath)
+		if collect {
+			copiedFiles = append(copiedFiles, destPath)
+		}
 	}
 	for _, u := range updates {
 		err := CopyTimestamps(u.fi, u.dest)
@@ -944,7 +946,7 @@ func CopyTree(src, dest string, context FileContext) error {
 	if err != nil {
 		return err
 	}
-	_, err = copyDirInner(files, src, dest, context, DoNotChangeUID, DoNotChangeGID, mode.Set{}, true, false)
+	_, err = copyDirInner(files, src, dest, context, DoNotChangeUID, DoNotChangeGID, mode.Set{}, true, false, false)
 	return err
 }
 
@@ -1362,7 +1364,7 @@ func CopyPaths(srcRoot, dstRoot string, paths []string) error {
 			files = append(files, filepath.Join(p, f))
 		}
 	}
-	_, err := copyDirInner(files, srcRoot, dstRoot, FileContext{}, DoNotChangeUID, DoNotChangeGID, mode.Set{}, true, true)
+	_, err := copyDirInner(files, srcRoot, dstRoot, FileContext{}, DoNotChangeUID, DoNotChangeGID, mode.Set{}, true, true, false)
 	return err
 }
 

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -763,7 +763,8 @@ func DetermineTargetFileOwnership(fi os.FileInfo, uid, gid int64) (int64, int64)
 }
 
 type timestampUpdate struct {
-	src, dest string
+	fi   os.FileInfo
+	dest string
 }
 
 // CopyDir copies the file or directory at src to dest
@@ -798,7 +799,6 @@ func copyDirInner(files []string, src, dest string, context FileContext, uid, gi
 			logrus.Debugf("Skipping copy for ignored path: %s", destPath)
 			continue
 		}
-		isHardlink := false
 		if file == "." && fi.IsDir() {
 			logrus.Tracef("Creating directory %s", destPath)
 
@@ -849,7 +849,6 @@ func copyDirInner(files []string, src, dest string, context FileContext, uid, gi
 			if err := os.Link(linkDst, destPath); err != nil {
 				return nil, err
 			}
-			isHardlink = true
 		} else if fi.Mode()&os.ModeNamedPipe != 0 {
 			// Opening a fifo blocks until it has a writer, so recreate it instead.
 			exclude, err := CreateFifo(fullPath, destPath, fi, context, uid, gid, chmod, useDefaultChmod, skipIgnoreList)
@@ -870,13 +869,14 @@ func copyDirInner(files []string, src, dest string, context FileContext, uid, gi
 			// This loop already skipped matches
 			assert.Assert("util.copydir.file-not-excluded", !exclude, "CopyFile refused to copy %s to %s", fullPath, destPath)
 		}
-		if !IsSymlink(fi) && !isHardlink {
-			updates = append(updates, timestampUpdate{src: fullPath, dest: destPath})
+		// The branches above that do not set their own timestamps.
+		if fi.IsDir() || fi.Mode()&os.ModeNamedPipe != 0 {
+			updates = append(updates, timestampUpdate{fi: fi, dest: destPath})
 		}
 		copiedFiles = append(copiedFiles, destPath)
 	}
 	for _, u := range updates {
-		err := CopyTimestamps(u.src, u.dest)
+		err := CopyTimestamps(u.fi, u.dest)
 		if err != nil {
 			return nil, err
 		}
@@ -1049,7 +1049,7 @@ func CopyFile(src, dest string, context FileContext, uid, gid int64, chmod mode.
 		return false, err
 	}
 
-	err = CopyTimestamps(src, dest)
+	err = CopyTimestamps(fi, dest)
 	if err != nil {
 		return false, err
 	}
@@ -1346,7 +1346,7 @@ func CopyFileOrSymlink(src string, destDir string, root string) error {
 	if err := os.Chmod(destFile, fi.Mode()); err != nil {
 		return fmt.Errorf("copying file mode: %w", err)
 	}
-	if err := CopyTimestamps(src, destFile); err != nil {
+	if err := CopyTimestamps(fi, destFile); err != nil {
 		return fmt.Errorf("copying file timestamps: %w", err)
 	}
 
@@ -1432,19 +1432,15 @@ func CopyCapabilities(src string, dest string) error {
 	return nil
 }
 
-// CopyTimestamps copies the file timestamps from src to dest
-func CopyTimestamps(src string, dest string) error {
-	fi, err := os.Lstat(src)
-	if err != nil {
-		return err
-	}
+// CopyTimestamps copies the file timestamps from fi to dest
+func CopyTimestamps(fi os.FileInfo, dest string) error {
 	stat, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {
-		return fmt.Errorf("failed to retrieve timestamps from: %s", src)
+		return fmt.Errorf("failed to retrieve timestamps from: %s", fi.Name())
 	}
 	atime := time.Time{}
 	mtime := time.Unix(stat.Mtim.Sec, stat.Mtim.Nsec)
-	err = os.Chtimes(dest, atime, mtime)
+	err := os.Chtimes(dest, atime, mtime)
 	if err != nil {
 		return fmt.Errorf("failed to copy timestamps: %w", err)
 	}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -862,7 +862,7 @@ func copyDirInner(files []string, src, dest string, context FileContext, uid, gi
 			continue
 		} else {
 			// ... Else, we want to copy over a file
-			exclude, err := CopyFile(fullPath, destPath, context, uid, gid, chmod, useDefaultChmod, skipIgnoreList)
+			exclude, err := CopyFile(fullPath, destPath, fi, context, uid, gid, chmod, useDefaultChmod, skipIgnoreList)
 			if err != nil {
 				return nil, err
 			}
@@ -1010,7 +1010,7 @@ func CopySymlink(src, dest string, context FileContext, skipIgnoreList bool) (bo
 }
 
 // CopyFile copies the file at src to dest
-func CopyFile(src, dest string, context FileContext, uid, gid int64, chmod mode.Set, useDefaultChmod bool, skipIgnoreList bool) (bool, error) {
+func CopyFile(src, dest string, fi os.FileInfo, context FileContext, uid, gid int64, chmod mode.Set, useDefaultChmod bool, skipIgnoreList bool) (bool, error) {
 	if context.ExcludesFile(src) {
 		logrus.Debugf("%s found in .dockerignore, ignoring", src)
 		return true, nil
@@ -1026,10 +1026,6 @@ func CopyFile(src, dest string, context FileContext, uid, gid int64, chmod mode.
 		// We have to make sure we do this so we don't overwrite our own file.
 		// See iusse #904 for an example.
 		return false, nil
-	}
-	fi, err := os.Stat(src)
-	if err != nil {
-		return false, err
 	}
 	logrus.Debugf("Copying file %s to %s", src, dest)
 	srcFile, err := FSys.Open(src)

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -708,7 +708,12 @@ func CreateFile(path string, reader io.Reader, perm os.FileMode, dirPerm os.File
 	if _, err := io.Copy(dest, reader); err != nil {
 		return fmt.Errorf("copying file: %w", err)
 	}
-	return setFilePermissions(path, perm, int(uid), int(gid))
+	if err := dest.Chown(int(uid), int(gid)); err != nil {
+		return err
+	}
+	// manually set permissions on file, since the default umask (022) will interfere
+	// Must chmod after chown because chown resets the file mode.
+	return dest.Chmod(perm)
 }
 
 // AddVolumePath adds the given path to the volume ignorelist.

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -691,16 +691,16 @@ func CreateFile(path string, reader io.Reader, perm os.FileMode, dirPerm os.File
 		return fmt.Errorf("creating parent dir: %w", err)
 	}
 
-	// if the file is already created with ownership other than root, reset the ownership
-	if FilepathExists(path) {
+	dest, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
+	if errors.Is(err, fs.ErrExist) {
+		// if the file is already created with ownership other than root, reset the ownership
 		logrus.Debugf("file at %v already exists, resetting file ownership to root", path)
-		err := resetFileOwnershipIfNotMatching(path, 0, 0)
+		err = resetFileOwnershipIfNotMatching(path, 0, 0)
 		if err != nil {
 			return fmt.Errorf("reseting file ownership: %w", err)
 		}
+		dest, err = os.Create(path)
 	}
-
-	dest, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("creating file: %w", err)
 	}

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -1411,7 +1411,12 @@ func Test_CopyFile_skips_self(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ignored, err := CopyFile(tempFile, tempFile, FileContext{}, DoNotChangeUID, DoNotChangeGID, mode.Set{}, true, false)
+	fi, err := os.Lstat(tempFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ignored, err := CopyFile(tempFile, tempFile, fi, FileContext{}, DoNotChangeUID, DoNotChangeGID, mode.Set{}, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #1048

`CopyDir` already holds the entry's `os.Lstat` result and then stats the same source twice more on the way down, once in `CopyFile` and once in `CopyTimestamps`, and stats the destination a third time in `CreateFile` right before creating it. Every regular file also gets its timestamps written twice, once by `CopyFile` and again by the replay loop at the end of `CopyDir`. That replay is there because writing a child moves the parent directory's mtime, so directories still need it, and so do fifos, which do not timestamp themselves. Regular files never did.

Measured on a copy of this repo's vendor tree, 4861 files and 1217 directories with no hardlinks, `newfstatat` drops from 35252 to 14591 and `utimensat` from 10939 to 6078. Both land at parity with `otiai10/copy` doing the same work on the same tree. Wall clock goes from 0.574s to 0.476s. What is left between us and the library is the `lgetxattr` per file that carries file capabilities across, which the library does not do at all.

The last two commits are unrelated to the stat counts. `copyDirInner` builds a slice of every destination path and `CopyTree` and `CopyPaths` both throw it away, only `CopyDir` has a caller that wants it. And `CreateFile` still holds the destination open when it sets the mode and owner, so it can use the descriptor instead of resolving the path twice more. That last one is worth about 3% on this tree, the same number of syscalls with no path walk in each.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - File and directory copy operations more reliably preserve source timestamps and metadata.
  - File creation applies ownership and permissions more consistently, including when the destination already exists.
  - Copy operations improve metadata accuracy for symbolic links, FIFOs, directories, and regular files.
  - Self-copy protection continues to work correctly during file operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->