### PR TITLE
inline the media type classification

### DIFF
--- a/pkg/image/transform.go
+++ b/pkg/image/transform.go
@@ -132,20 +132,11 @@ func AssertConsistentMediaType(img v1.Image) error {
 	if err != nil {
 		return err
 	}
-	oci, docker := false, false
-	classify := func(mt types.MediaType) {
-		s := string(mt)
-		switch {
-		case strings.Contains(s, types.OCIVendorPrefix):
-			oci = true
-		case strings.Contains(s, types.DockerVendorPrefix):
-			docker = true
-		}
-	}
-	classify(man.MediaType)
-	classify(man.Config.MediaType)
-	for _, l := range man.Layers {
-		classify(l.MediaType)
+	oci := strings.Contains(string(man.MediaType), types.OCIVendorPrefix)
+	docker := strings.Contains(string(man.MediaType), types.DockerVendorPrefix)
+	for _, l := range append([]v1.Descriptor{man.Config}, man.Layers...) {
+		oci = oci || strings.Contains(string(l.MediaType), types.OCIVendorPrefix)
+		docker = docker || strings.Contains(string(l.MediaType), types.DockerVendorPrefix)
 	}
 	assert.Assert("image.consistent-media-type", !(oci && docker), "manifest mixes OCI and docker media types")
 	return nil


### PR DESCRIPTION
AssertConsistentMediaType collected its two flags through a closure that every descriptor was fed to one at a time. The config descriptor and the layer descriptors are the same type, so folding them into one range drops the closure and lets the flags be plain expressions. No behaviour change, the same manifest, config and layer media types are classified as before.

One theoretical difference: the switch stopped at the first matching case, so a media type carrying both vendor prefixes only ever set the OCI flag. The new form sets both. No real media type carries both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal media type consistency checks while preserving existing behavior for OCI and Docker manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->